### PR TITLE
Client App [Tauri Updater] [On Progress]

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -657,6 +657,7 @@ function _Chat() {
     newm: () => navigate(Path.NewChat),
     prev: () => chatStore.nextSession(-1),
     next: () => chatStore.nextSession(1),
+    restart: () => window.__TAURI__?.process.relaunch(),
     clear: () =>
       chatStore.updateCurrentSession(
         (session) => (session.clearContextIndex = session.messages.length),

--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -683,9 +683,28 @@ export function Settings() {
             {checkingUpdate ? (
               <LoadingIcon />
             ) : hasNewVersion ? (
-              <Link href={updateUrl} target="_blank" className="link">
-                {Locale.Settings.Update.GoToUpdate}
-              </Link>
+              <>
+                {clientConfig?.isApp ? (
+                  <IconButton
+                    icon={<ResetIcon></ResetIcon>}
+                    text={Locale.Settings.Update.GoToUpdate}
+                    onClick={() => {
+                      window.__TAURI__?.updater.checkUpdate().then((updateResult) => {
+                        if (updateResult.status === "DONE") {
+                          window.__TAURI__?.updater.installUpdate();
+                        }
+                      }).catch((e) => {
+                        console.error("[Check Update Error]", e);
+                        showToast(Locale.Settings.Update.Failed);
+                      });
+                    }}
+                  />
+                ) : (
+                  <Link href={updateUrl} target="_blank" className="link">
+                    {Locale.Settings.Update.GoToUpdate}
+                  </Link>
+                )}
+              </>
             ) : (
               <IconButton
                 icon={<ResetIcon></ResetIcon>}

--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -565,6 +565,14 @@ export function Settings() {
     setCheckingUpdate(true);
     updateStore.getLatestVersion(force).then(() => {
       setCheckingUpdate(false);
+      window.__TAURI__?.updater.checkUpdate().then((updateResult) => {
+        if (updateResult.status === "DONE") {
+          window.__TAURI__?.updater.installUpdate();
+        }
+      }).catch((e) => {
+        console.error("[Check Update Error]", e);
+        showToast(Locale.Settings.Update.Failed);
+      });
     });
 
     console.log("[Update] local version ", updateStore.version);
@@ -686,18 +694,9 @@ export function Settings() {
               <>
                 {clientConfig?.isApp ? (
                   <IconButton
-                    icon={<ResetIcon></ResetIcon>}
+                    icon={<DownloadIcon></DownloadIcon>}
                     text={Locale.Settings.Update.GoToUpdate}
-                    onClick={() => {
-                      window.__TAURI__?.updater.checkUpdate().then((updateResult) => {
-                        if (updateResult.status === "DONE") {
-                          window.__TAURI__?.updater.installUpdate();
-                        }
-                      }).catch((e) => {
-                        console.error("[Check Update Error]", e);
-                        showToast(Locale.Settings.Update.Failed);
-                      });
-                    }}
+                    onClick={() => checkUpdate(true)}
                   />
                 ) : (
                   <Link href={updateUrl} target="_blank" className="link">

--- a/app/global.d.ts
+++ b/app/global.d.ts
@@ -34,5 +34,10 @@ declare interface Window {
       installUpdate(): Promise<void>;
       onUpdaterEvent(handler: (status: UpdateStatusResult) => void): Promise<UnlistenFn>;
     };
+    // can do route in client app like CORS fetch, currently is not enabled yet only module added.
+    http: {
+      fetch<T>(url: string, options?: FetchOptions): Promise<Response<T>>;
+      getClient(options?: ClientOptions): Promise<Client>
+    };
   };
 }

--- a/app/global.d.ts
+++ b/app/global.d.ts
@@ -37,7 +37,7 @@ declare interface Window {
     // can do route in client app like CORS fetch, currently is not enabled yet only module added.
     http: {
       fetch<T>(url: string, options?: FetchOptions): Promise<Response<T>>;
-      getClient(options?: ClientOptions): Promise<Client>
+      getClient(options?: ClientOptions): Promise<Client>;
     };
   };
 }

--- a/app/global.d.ts
+++ b/app/global.d.ts
@@ -25,5 +25,10 @@ declare interface Window {
       isPermissionGranted(): Promise<boolean>;
       sendNotification(options: string | Options): void;
     };
+    updater: {
+      checkUpdate(): Promise<UpdateResult>;
+      installUpdate(): Promise<void>;
+      onUpdaterEvent(handler: (status: UpdateStatusResult) => void): Promise<UnlistenFn>;
+    };
   };
 }

--- a/app/global.d.ts
+++ b/app/global.d.ts
@@ -24,6 +24,9 @@ declare interface Window {
     fs: {
       writeBinaryFile(path: string, data: Uint8Array): Promise<void>;
     };
+    process: {
+      relaunch(): Promise<void>;
+    };
     notification:{
       requestPermission(): Promise<Permission>;
       isPermissionGranted(): Promise<boolean>;

--- a/app/global.d.ts
+++ b/app/global.d.ts
@@ -16,6 +16,10 @@ declare interface Window {
     invoke(command: string, payload?: Record<string, unknown>): Promise<any>;
     dialog: {
       save(options?: Record<string, unknown>): Promise<string | null>;
+      open(options?: OpenDialogOptions): Promise<null | string | string[]>;
+      // support locale language
+      message(message: string, options?: string | MessageDialogOptions): Promise<void>;
+      ask(message: string, options?: string | ConfirmDialogOptions): Promise<boolean>;
     };
     fs: {
       writeBinaryFile(path: string, data: Uint8Array): Promise<void>;

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -48,6 +48,7 @@ const cn = {
       newm: "从面具新建聊天",
       next: "下一个聊天",
       prev: "上一个聊天",
+      restart: "重新启动客户端",
       clear: "清除上下文",
       del: "删除聊天",
     },

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -167,6 +167,8 @@ const cn = {
       IsChecking: "正在检查更新...",
       FoundUpdate: (x: string) => `发现新版本：${x}`,
       GoToUpdate: "前往更新",
+      Success: "更新成功。",
+      Failed: "更新失败。",
     },
     SendKey: "发送键",
     Theme: "主题",

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -169,6 +169,8 @@ const en: LocaleType = {
       IsChecking: "Checking update...",
       FoundUpdate: (x: string) => `Found new version: ${x}`,
       GoToUpdate: "Update",
+      Success: "Update Succesfull.",
+      Failed: "Update Failed.",
     },
     SendKey: "Send Key",
     Theme: "Theme",

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -50,6 +50,7 @@ const en: LocaleType = {
       newm: "Start a new chat with mask",
       next: "Next Chat",
       prev: "Previous Chat",
+      restart: "Restart a client",
       clear: "Clear Context",
       del: "Delete Chat",
     },

--- a/app/locales/id.ts
+++ b/app/locales/id.ts
@@ -37,6 +37,7 @@ const id: PartialLocaleType = {
       newm: "Mulai Chat Baru dengan Masks",
       next: "Chat Selanjutnya",
       prev: "Chat Sebelumnya",
+      restart: "Restart klien",
       clear: "Bersihkan Percakapan",
       del: "Hapus Chat",
     },

--- a/app/locales/id.ts
+++ b/app/locales/id.ts
@@ -156,6 +156,8 @@ const id: PartialLocaleType = {
       IsChecking: "Memeriksa pembaruan...",
       FoundUpdate: (x: string) => `Versi terbaru ditemukan: ${x}`,
       GoToUpdate: "Perbarui Sekarang",
+      Success: "Pembaruan Berhasil.",
+      Failed: "Pembaruan Gagal.",
     },
     AutoGenerateTitle: {
       Title: "Hasilkan Judul Otomatis",

--- a/app/store/update.ts
+++ b/app/store/update.ts
@@ -4,6 +4,7 @@ import { getClientConfig } from "../config/client";
 import { createPersistStore } from "../utils/store";
 import ChatGptIcon from "../icons/chatgpt.png";
 import Locale from "../locales";
+import { showToast } from "../components/ui-lib";
 
 const ONE_MINUTE = 60 * 1000;
 const isApp = !!getClientConfig()?.isApp;
@@ -108,6 +109,16 @@ export const useUpdateStore = createPersistStore(
                       body: updateMessage,
                       icon: `${ChatGptIcon.src}`,
                       sound: "Default"
+                    });
+                    // this a wild for updating client app
+                    window.__TAURI__?.updater.checkUpdate().then((updateResult) => {
+                      if (updateResult.status === "DONE") {
+                        window.__TAURI__?.updater.installUpdate();
+                        showToast(Locale.Settings.Update.Success);
+                      }
+                    }).catch((e) => {
+                      console.error("[Check Update Error]", e);
+                      showToast(Locale.Settings.Update.Failed);
                     });
                   }
                 }

--- a/app/store/update.ts
+++ b/app/store/update.ts
@@ -114,7 +114,6 @@ export const useUpdateStore = createPersistStore(
                     window.__TAURI__?.updater.checkUpdate().then((updateResult) => {
                       if (updateResult.status === "DONE") {
                         window.__TAURI__?.updater.installUpdate();
-                        showToast(Locale.Settings.Update.Success);
                       }
                     }).catch((e) => {
                       console.error("[Check Update Error]", e);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -93,7 +93,7 @@
       "endpoints": [
         "https://github.com/Yidadaa/ChatGPT-Next-Web/releases/latest/download/latest.json"
       ],
-      "dialog": false,
+      "dialog": true,
       "windows": {
         "installMode": "passive"
       },


### PR DESCRIPTION
### This A wild for client app update instead of click `update` manually in setting

![Screenshot_244](https://github.com/Yidadaa/ChatGPT-Next-Web/assets/17626300/8af6258c-2c58-4716-a97a-2f00d937a17f)
![Screenshot_245](https://github.com/Yidadaa/ChatGPT-Next-Web/assets/17626300/e35e276d-8e02-4856-88bf-c43ed4a4c2ad)

Commits Log : 

[+] feat(global.d.ts): add updater interface to the Window interface
[+] feat(cn.ts): add success and failed translations for update
[+] feat(en.ts): add success and failed translations for update
[+] feat(id.ts): add success and failed translations for update
[+] feat(update.ts): add logic to check and install updates, and show toast messages for success and failure
[+] fix(tauri.conf.json): enable dialog for Tauri updater

Note : Dialog Update Tauri doesn't support using local language so default its english



