### PR TITLE
fix: remove the content-encoding header

### DIFF
--- a/app/api/common.ts
+++ b/app/api/common.ts
@@ -106,6 +106,12 @@ export async function requestOpenai(req: NextRequest) {
     // to disable nginx buffering
     newHeaders.set("X-Accel-Buffering", "no");
 
+    // The latest version of the OpenAI API forced the content-encoding to be "br" in json response
+    // So if the streaming is disabled, we need to remove the content-encoding header
+    // But vercel uses gzip to compress the response
+    // So we need to remove the content-encoding header
+    newHeaders.delete("content-encoding");
+
     return new Response(res.body, {
       status: res.status,
       statusText: res.statusText,

--- a/app/api/common.ts
+++ b/app/api/common.ts
@@ -108,8 +108,8 @@ export async function requestOpenai(req: NextRequest) {
 
     // The latest version of the OpenAI API forced the content-encoding to be "br" in json response
     // So if the streaming is disabled, we need to remove the content-encoding header
-    // But vercel uses gzip to compress the response
-    // So we need to remove the content-encoding header
+    // Because Vercel uses gzip to compress the response, if we don't remove the content-encoding header
+    // The browser will try to decode the response with brotli and fail
     newHeaders.delete("content-encoding");
 
     return new Response(res.body, {


### PR DESCRIPTION
The latest version of the OpenAI API forced the `content-encoding` to be `brotli` in json response so if the streaming is disabled, we need to remove the `content-encoding` header from the response of openai.
This is because Vercel uses gzip to compress the response data, if we don't remove the `content-encoding` header the browser will try to decode the response with `brotli` and cause a decompression fail.

![image](https://github.com/Yidadaa/ChatGPT-Next-Web/assets/316498/94a9a929-f0a1-490d-b1eb-a93750ed5e39)
