### PR TITLE
feat: add temporary support for Cloudflare AI Gateway OpenAI path

### DIFF
--- a/app/api/common.ts
+++ b/app/api/common.ts
@@ -28,6 +28,10 @@ export async function requestOpenai(req: NextRequest) {
     baseUrl = baseUrl.slice(0, -1);
   }
 
+  if (baseUrl.includes("gateway.ai.cloudflare.com")) {
+    path = path.replace(/^v1\//, '');
+  }
+
   console.log("[Proxy] ", path);
   console.log("[Base Url]", baseUrl);
   console.log("[Org ID]", serverConfig.openaiOrgId);


### PR DESCRIPTION
Added support for Cloudflare AI Gateway. When using the OpenAI proxy with Cloudflare AI Gateway, an error of "invalid URL (post /v1/v1/chat/completions)" occurs because 'v1' already exists in the baseUrl. A temporary solution is to remove 'v1' from the path when detecting the use of Cloudflare AI Gateway. As I do not have access to Azure OpenAI services, I was unable to test the Azure proxy for Cloudflare AI Gateway.