### PR TITLE
ci: add .dockerignore to exclude env files to prevent potential key leakages 避免潜在的密钥泄漏

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# local env files
+.env*.local
+
+# docker-compose env files
+.env
+
+*.key
+*.key.pub


### PR DESCRIPTION
**What changes are made 变更的内容**
Add a `.dockerignore` file to exclude the env files when building the image locally.
添加了`.dockerignore`文件，以在本地构建镜像时排除环境变量相关文件。

**Why does it matter 变更的原因**
When developing and building the docker image locally, if a `.env` file is used to specify the API key and access code, it will be included in the image that is built locally, thus leads to a secret key leak when the image is pushed to a public docker registry. 
(This week we encountered an OpenAI API key leakage. Upon investigation, it was found to be caused by the inclusion of the `.env` file in the image.)
在本地开发和构建Docker镜像时，如果使用.env文件来指定API密钥和密码，并在本地构建镜像，`.env`文件将会包含在构建的镜像中。当该镜像被推到公开的Docker Registry时，会导致密钥泄露。
（本周遇到了OpenAI API密钥泄露的问题，经排查发现为镜像中包含`.env`文件所致）

**How the .env file is included into the image**
```Dockerfile
COPY . .
# .env file is copied from the codebase into the image working directory
RUN yarn build
# yarn build includes the .env file in /app/.next/standalone
......
COPY --from=builder /app/.next/standalone ./
# .env file is copied into the base working directory in the image
```

**The file structure inside the image**
```
$ docker exec -it chatgpt-next-web sh
/app # ls -a
.  ..   .env  .next  node_modules  package.json  public  server.js
```