### PR TITLE
Fix 修改了cloudflare部署说明及成功部署要点

### DIFF
--- a/docs/cloudflare-pages-cn.md
+++ b/docs/cloudflare-pages-cn.md
@@ -8,6 +8,15 @@
 2. 选择 "Connect to Git"。
 3. 关联 Cloudflare Pages 和你的 GitHub 账号。
 4. 选中你 fork 的此项目。
+
+>**在cloudflare部署前需要修改下面三个文件的runtime才能完成部署**
+   - `/app/api/config/route.ts`
+   - `/app/cors/[...path]/route.ts`
+   - `/app/openai/[...path]/route.ts`
+>将这三个文件内容的export const runtime值修改成edge
+
+   - `例如：export const runtime = "edge";`
+
 5. 点击 "Begin setup"。
 6. 对于 "Project name" 和 "Production branch"，可以使用默认值，也可以根据需要进行更改。
 7. 在 "Build Settings" 中，选择 "Framework presets" 选项并选择 "Next.js"。

--- a/docs/cloudflare-pages-en.md
+++ b/docs/cloudflare-pages-en.md
@@ -9,6 +9,13 @@ Fork this project on GitHub, then log in to dash.cloudflare.com and go to Pages.
 3. Connect Cloudflare Pages to your GitHub account.
 4. Select the forked project.
 5. Click "Begin setup".
+>**Before deploying on Cloudflare, you need to modify the runtime in the following three files to complete the deployment**
+   - `/app/api/config/route.ts`
+   - `/app/cors/[...path]/route.ts`
+   - `/app/openai/[...path]/route.ts`
+>Change the value of export const runtime in these three files to edge
+
+   - `For example: export const runtime = "edge";`
 6. For "Project name" and "Production branch", use the default values or change them as needed.
 7. In "Build Settings", choose the "Framework presets" option and select "Next.js".
 8. Do not use the default "Build command" due to a node:buffer bug. Instead, use the following command:

--- a/docs/cloudflare-pages-es.md
+++ b/docs/cloudflare-pages-es.md
@@ -9,6 +9,13 @@ Bifurca el proyecto en Github, luego inicia sesión en dash.cloudflare.com y ve 
 3.  Vincula páginas de Cloudflare a tu cuenta de GitHub.
 4.  Seleccione este proyecto que bifurcó.
 5.  Haga clic en "Comenzar configuración".
+>**Antes de desplegar en Cloudflare, es necesario modificar el runtime en los siguientes tres archivos para completar el despliegue**
+   - `/app/api/config/route.ts`
+   - `/app/cors/[...path]/route.ts`
+   - `/app/openai/[...path]/route.ts`
+>Cambiar el valor de export const runtime en estos tres archivos a edge
+
+   - `Por ejemplo: export const runtime = "edge";`
 6.  Para "Nombre del proyecto" y "Rama de producción", puede utilizar los valores predeterminados o cambiarlos según sea necesario.
 7.  En Configuración de compilación, seleccione la opción Ajustes preestablecidos de Framework y seleccione Siguiente.js.
 8.  Debido a los errores de node:buffer, no use el "comando Construir" predeterminado por ahora. Utilice el siguiente comando:

--- a/docs/cloudflare-pages-ja.md
+++ b/docs/cloudflare-pages-ja.md
@@ -8,6 +8,13 @@ GitHub でこのプロジェクトをフォークし、dash.cloudflare.com に�
 3. Cloudflare Pages を GitHub アカウントに接続します。
 4. フォークしたプロジェクトを選択します。
 5. "Begin setup" をクリックする。
+>**Cloudflareにデプロイする前に、デプロイを完了するために以下の3つのファイルのruntimeを変更する必要があります**
+   - `/app/api/config/route.ts`
+   - `/app/cors/[...path]/route.ts`
+   - `/app/openai/[...path]/route.ts`
+>これら3つのファイルのexport const runtimeの値をedgeに変更します
+
+   - `例：export const runtime = "edge";`
 6. "Project name" と "Production branch" はデフォルト値を使用するか、必要に応じて変更してください。
 7. "Build Settings" で、"Framework presets" オプションを選択し、"Next.js" を選択します。
 8. node:buffer のバグのため、デフォルトの "Build command" は使用しないでください。代わりに、以下のコマンドを使用してください:

--- a/docs/cloudflare-pages-ko.md
+++ b/docs/cloudflare-pages-ko.md
@@ -8,6 +8,13 @@
 3. Cloudflare 페이지를 GitHub 계정과 연결합니다.
 4. 포크한 프로젝트를 선택합니다.
 5. "설정 시작"을 클릭합니다.
+>**Cloudflare에 배포하기 전에 다음 세 파일의 런타임을 수정하여 배포를 완료해야 합니다**
+   - `/app/api/config/route.ts`
+   - `/app/cors/[...path]/route.ts`
+   - `/app/openai/[...path]/route.ts`
+>이 세 파일의 export const runtime 값을 edge로 변경하십시오
+
+   - `예: export const runtime = "edge";`
 6. "프로젝트 이름" 및 "프로덕션 브랜치"의 기본값을 사용하거나 필요에 따라 변경합니다.
 7. "빌드 설정"에서 "프레임워크 프리셋" 옵션을 선택하고 "Next.js"를 선택합니다.
 8. node:buffer 버그로 인해 지금은 기본 "빌드 명령어"를 사용하지 마세요. 다음 명령을 사용하세요:


### PR DESCRIPTION
修改了cloudflare部署说明及成功部署要点，及同步更新cloudflare-pages多个语言版本的说明

>**在cloudflare部署前需要修改下面三个文件的runtime才能完成部署**
   - `/app/api/config/route.ts`
   - `/app/cors/[...path]/route.ts`
   - `/app/openai/[...path]/route.ts`
>将这三个文件内容的export const runtime值修改成edge
   - `例如：export const runtime = "edge";`

部署成功证明截图：
![image](https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/assets/49397496/6b30a512-2330-4b5d-b826-9fca47527f12)
![image](https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/assets/49397496/ef987112-c424-425f-833c-8744c69b43f0)
