### PR TITLE
fix: change "allowed hashed codes" log output format

### DIFF
--- a/app/api/auth.ts
+++ b/app/api/auth.ts
@@ -33,7 +33,7 @@ export function auth(req: NextRequest) {
   const hashedCode = md5.hash(accessCode ?? "").trim();
 
   const serverConfig = getServerSideConfig();
-  console.log("[Auth] allowed hashed codes: ", [...serverConfig.codes]);
+  console.log("[Auth] allowed hashed codes: ", Array.from(serverConfig.codes).join(', '));
   console.log("[Auth] got access code:", accessCode);
   console.log("[Auth] hashed access code:", hashedCode);
   console.log("[User IP] ", getIP(req));


### PR DESCRIPTION
When using Vercel's Log Drains feature to send logs to a third-party logging service, since the original "[...serverConfig.codes]" is an array, Vercel sends log data for each element, resulting in a large number of separate, hard-to-read logs when there are many codes. Modify this part to "Array.from(serverConfig.codes).join(', ')" to print all allowed hashed codes on a single line of the log.