### PR TITLE
Fix: Routes `/api/cors/[...path]` was not configured to run with the …

### DIFF
--- a/app/api/cors/[...path]/route.ts
+++ b/app/api/cors/[...path]/route.ts
@@ -40,4 +40,4 @@ export const POST = handle;
 export const GET = handle;
 export const OPTIONS = handle;
 
-export const runtime = "nodejs";
+export const runtime = "edge";


### PR DESCRIPTION
Fix: `ERROR: Failed to produce a Cloudflare Pages build from the project.`

```
The following routes were not configured to run with the Edge Runtime:
        - /api/cors/[...path]
```