### PR TITLE
fix: webdav check httpcode list

### DIFF
--- a/app/utils/cloud/webdav.ts
+++ b/app/utils/cloud/webdav.ts
@@ -20,8 +20,15 @@ export function createWebDavClient(store: SyncStore) {
           headers: this.headers(),
           proxyUrl,
         });
-        console.log("[WebDav] check", res.status, res.statusText);
-        return [201, 200, 404, 301, 302, 307, 308].includes(res.status);
+        const success = [201, 200, 404, 405, 301, 302, 307, 308].includes(
+          res.status,
+        );
+        console.log(
+          `[WebDav] check ${success ? "success" : "failed"}, ${res.status} ${
+            res.statusText
+          }`,
+        );
+        return success;
       } catch (e) {
         console.error("[WebDav] failed to check", e);
       }


### PR DESCRIPTION

我使用了 [dufs][dufs] 去搭建 webdav server, 当使用 `MKCOL` method 创建一个已存在的路径时，它会返回 405，但是 ChatGPT-Next-Web 中使用了 `MKCOL` method 去探测可用性，所以每次探测都会失败

<img width="692" alt="image" src="https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/assets/38343778/d9872911-3637-4b37-a139-1c3c025650e0">

所以在 check 函数中加上了 `405` 这个状态码

或者我觉得应该换一种方式去 check，而不是使用 `MKCOL` 这种方式？

[dufs]: https://github.com/sigoden/dufs