### PR TITLE
fix: cors fetch

### DIFF
--- a/app/utils/cors.ts
+++ b/app/utils/cors.ts
@@ -25,12 +25,16 @@ export function corsFetch(
     throw Error("[CORS Fetch] url must starts with http/https");
   }
 
-  let proxyUrl = options.proxyUrl ?? corsPath(ApiPath.Cors);
-  if (!proxyUrl.endsWith("/")) {
-    proxyUrl += "/";
-  }
+  let corsUrl = url;
+  if (options.proxyUrl) {
+    let proxyUrl = options.proxyUrl;
+    if (!proxyUrl.endsWith("/")) {
+      proxyUrl += "/";
+    }
 
-  url = url.replace("://", "/");
+    url = url.replace("://", "/");
+    corsUrl = proxyUrl + url;
+  }
 
   const corsOptions = {
     ...options,
@@ -43,8 +47,6 @@ export function corsFetch(
       : options.headers,
   };
 
-  const corsUrl = proxyUrl + url;
   console.info("[CORS] target = ", corsUrl);
-
   return fetch(corsUrl, corsOptions);
 }


### PR DESCRIPTION
现在的 corsFetch 的实现里面，不管有没有开启「启用代理」，都会走代理，如果没有开启「启用代理」，就会走默认的 `/api/cors`，这应该是不合理的，因为有的 webdav 服务器可以支持跨域，所以修改了一下，使得其更加合理

<img width="835" alt="image" src="https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/assets/38343778/7154497b-ffb7-4b75-9da9-9d35e76ad0a8">
