### PR TITLE
Remove default ENV to allow user provide environment variables via env files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,6 @@ WORKDIR /app
 RUN apk add proxychains-ng
 
 ENV PROXY_URL=""
-ENV OPENAI_API_KEY=""
-ENV GOOGLE_API_KEY=""
-ENV CODE=""
 
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/standalone ./


### PR DESCRIPTION
NextJS app allow user define environment variables by providing a `.env.local` file in `/app/`. 

Those related lines in the Dockerfile are setting values to the environment variables, which will be passed in as `process.env`, which ranked as the top one in the [loading order](https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#environment-variable-load-order)

This PR is removing these default variables so that user can just mount a `.env.local` file to set environment variable, which can avoid include the sensitive information in the docker-compose file.