### PR TITLE
update google api region

### DIFF
--- a/app/api/google/[...path]/route.ts
+++ b/app/api/google/[...path]/route.ts
@@ -101,19 +101,14 @@ export const POST = handle;
 
 export const runtime = "edge";
 export const preferredRegion = [
-  "arn1",
   "bom1",
-  "cdg1",
   "cle1",
   "cpt1",
-  "dub1",
-  "fra1",
   "gru1",
   "hnd1",
   "iad1",
   "icn1",
   "kix1",
-  "lhr1",
   "pdx1",
   "sfo1",
   "sin1",


### PR DESCRIPTION
因为部分地区不支持 Gemini API，所以修改 vercel 可能部署的区域。
参考：
1. https://ai.google.dev/available_regions?hl=zh-cn
2. https://vercel.com/docs/edge-network/regions#region-list