### PR TITLE
feat: Add Japanese translations for ChatGPT messages

### DIFF
--- a/app/locales/jp.ts
+++ b/app/locales/jp.ts
@@ -12,6 +12,13 @@ const jp: PartialLocaleType = {
   },
   Chat: {
     SubTitle: (count: number) => `ChatGPTとの ${count} 通のチャット`,
+    EditMessage: {
+      Title: "全てのメッセージを修正",
+      Topic: {
+        Title: "トピック",
+        SubTitle: "このトピックを変える",
+      },
+    },
     Actions: {
       ChatList: "メッセージリストを表示",
       CompressedHistory: "圧縮された履歴プロンプトを表示",
@@ -47,6 +54,28 @@ const jp: PartialLocaleType = {
     Download: "ファイルをダウンロード",
     MessageFromYou: "あなたからのメッセージ",
     MessageFromChatGPT: "ChatGPTからのメッセージ",
+    Format: {
+      Title: "フォーマットをエクスポート",
+      SubTitle: "マークダウン形式、PNG画像形式を選択できます。",
+    },
+    IncludeContext: {
+      Title: "コンテキストを含みますか？",
+      SubTitle: "コンテキストを含ませるか否か",
+    },
+    Steps: {
+      Select: "エクスポート設定",
+      Preview: "プレビュー",
+    },
+    Image: {
+      Toast: "画像生成中...",
+      Modal: "長押し、または右クリックで保存してください。",
+    },
+  },
+  Select: {
+    Search: "検索",
+    All: "すべて選択",
+    Latest: "新しいメッセージを選択",
+    Clear: "クリア",
   },
   Memory: {
     Title: "履歴メモリ",
@@ -118,6 +147,10 @@ const jp: PartialLocaleType = {
         Title: "キャラクターページ",
         SubTitle: "新規チャット作成時にキャラクターページを表示する",
       },
+      Builtin: {
+        Title: "ビルトインマスクを非表示",
+        SubTitle: "マスクリストからビルトインを非表示する",
+      },
     },
     Prompt: {
       Disable: {
@@ -157,7 +190,6 @@ const jp: PartialLocaleType = {
       Check: "再確認",
       NoAccess: "APIキーまたはアクセスパスワードを入力して残高を表示",
     },
-
     Model: "モデル (model)",
     Temperature: {
       Title: "ランダム性 (temperature)",
@@ -175,6 +207,10 @@ const jp: PartialLocaleType = {
     FrequencyPenalty: {
       Title: "話題の頻度 (frequency_penalty)",
       SubTitle: "値が大きいほど、重複語を低減する可能性が高くなります",
+    },
+    AutoGenerateTitle: {
+      Title: "タイトルの自動生成",
+      SubTitle: "会話内容に基づいて適切なタイトルを生成する",
     },
   },
   Store: {


### PR DESCRIPTION
We noticed that the Japanese translation was missing compared to the English and Chinese versions.

This pull request adds Japanese translations of code-based ChatGPT messages.

Note: Some parts of the settings screen are still missing in translation.