### PR TITLE
Fix temperature range

### DIFF
--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -91,7 +91,7 @@ export const ModalConfigValidator = {
     return limitNumber(x, -2, 2, 0);
   },
   temperature(x: number) {
-    return limitNumber(x, 0, 1, 1);
+    return limitNumber(x, 0, 2, 1);
   },
   top_p(x: number) {
     return limitNumber(x, 0, 1, 1);


### PR DESCRIPTION
Fix temperature range according to OpenAI's official [API documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-temperature).

> What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.