### PR TITLE
Fix [Utils] Replace Text Encoder

### DIFF
--- a/app/utils.ts
+++ b/app/utils.ts
@@ -56,10 +56,8 @@ export async function downloadAs(text: string, filename: string) {
 
     if (result !== null) {
       try {
-        await window.__TAURI__.fs.writeBinaryFile(
-          result,
-          new Uint8Array([...text].map((c) => c.charCodeAt(0))),
-        );
+        const encoder = new TextEncoder();
+        await window.__TAURI__.fs.writeBinaryFile(result, encoder.encode(text));
         showToast(Locale.Download.Success);
       } catch (error) {
         showToast(Locale.Download.Failed);


### PR DESCRIPTION
[+] fix(utils.ts): replace text encoder

Use a better way of encoding text, the current code is wrong.
```
new Uint8Array([...'新的对话'].map((c) => c.charCodeAt(0)))
// => Uint8Array(4) [176, 132, 249, 221]
```

Replacing old code with TextEncoder.
```
const encoder = new TextEncoder()
encoder.encode('新的对话')
// => Uint8Array(12) [230, 150, 176, 231, 154, 132, 229, 175, 185, 232, 175, 157]
```