### PR TITLE
fix: a ts type error

### DIFF
--- a/app/components/markdown.tsx
+++ b/app/components/markdown.tsx
@@ -60,7 +60,7 @@ export function Mermaid(props: { code: string }) {
   );
 }
 
-export function PreCode(props: { children: any }) {
+export function PreCode(props: any) {
   const ref = useRef<HTMLPreElement>(null);
   const refText = ref.current?.innerText;
   const [mermaidCode, setMermaidCode] = useState("");


### PR DESCRIPTION
Fix an error at markdown.tsx line 139 `pre: PreCode,`:
> 不能将类型“(props: { children: any; }) => Element”分配给类型“keyof IntrinsicElements | Component<ClassAttributes<HTMLPreElement> & HTMLAttributes<HTMLPreElement> & ExtraProps> | undefined”。
>   不能将类型“(props: { children: any; }) => Element”分配给类型“FunctionComponent<ClassAttributes<HTMLPreElement> & HTMLAttributes<HTMLPreElement> & ExtraProps>”。
>     参数“props”和“props” 的类型不兼容。
>       不能将类型“ClassAttributes<HTMLPreElement> & HTMLAttributes<HTMLPreElement> & ExtraProps”分配给类型“{ children: any; }”。
>         属性“children”在类型“ClassAttributes<HTMLPreElement> & HTMLAttributes<HTMLPreElement> & ExtraProps”中为可选，但在类型“{ children: any; }”中为必选。