### PR TITLE
support \(...\) and \[...\] style math formula

### DIFF
--- a/app/components/markdown.tsx
+++ b/app/components/markdown.tsx
@@ -116,9 +116,27 @@ function escapeDollarNumber(text: string) {
   return escapedText;
 }
 
+function escapeBrackets(text: string) {
+  const pattern =
+    /(```[\s\S]*?```|`.*?`)|\\\[([\s\S]*?[^\\])\\\]|\\\((.*?)\\\)/g;
+  return text.replace(
+    pattern,
+    (match, codeBlock, squareBracket, roundBracket) => {
+      if (codeBlock) {
+        return codeBlock;
+      } else if (squareBracket) {
+        return `$$${squareBracket}$$`;
+      } else if (roundBracket) {
+        return `$${roundBracket}$`;
+      }
+      return match;
+    },
+  );
+}
+
 function _MarkDownContent(props: { content: string }) {
   const escapedContent = useMemo(
-    () => escapeDollarNumber(props.content),
+    () => escapeBrackets(escapeDollarNumber(props.content)),
     [props.content],
   );
 


### PR DESCRIPTION
解决gpt回复的公式使用 \\(...\\) 和 \\[...\\] 格式导致的渲染问题  https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/issues/3436#issuecomment-1842626873

remark-math 里有人讨论了这个问题，不过结论是不会支持这种格式 https://github.com/remarkjs/remark-math/issues/39
曾尝试用rehype-mathjax来代替rehype-katex，不过也没有正确渲染

最后参考了这里的实现，把\\(...\\) 和 \\[...\\]格式替换为美元符号：
https://github.com/danny-avila/LibreChat/pull/1585
https://github.com/danny-avila/LibreChat/blob/v0.6.10/client/src/utils/latex.ts#L36

现在的效果：
![均方误差的公式](https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/assets/28617777/37787e82-4acb-46bc-83d7-fcf9dc53328c)

此前的效果：
![模型评估](https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/assets/28617777/745bb7b3-238b-4de4-83fd-2958bcd0ccfa)
