### PR TITLE
perf: extract component and use zustand selector to optimize render ui perfermance and reduce re-render

### DIFF
--- a/app/hooks/use-event-callback.ts
+++ b/app/hooks/use-event-callback.ts
@@ -1,0 +1,20 @@
+import { useLayoutEffect, useMemo, useRef } from "react";
+
+type Fn<ARGS extends any[], R> = (...args: ARGS) => R;
+
+export const useEventCallback = <A extends any[], R>(
+  fn: Fn<A, R>,
+): Fn<A, R> => {
+  let ref = useRef<Fn<A, R>>(fn);
+  useLayoutEffect(() => {
+    ref.current = fn;
+  });
+  return useMemo(
+    () =>
+      (...args: A): R => {
+        const { current } = ref;
+        return current(...args);
+      },
+    [],
+  );
+};

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "emoji-picker-react": "^4.5.15",
     "fuse.js": "^7.0.0",
     "html-to-image": "^1.11.11",
+    "immer": "10.0.3",
     "mermaid": "^10.6.1",
     "nanoid": "^5.0.3",
     "next": "^13.4.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3722,6 +3722,11 @@ ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
+immer@10.0.3:
+  version "10.0.3"
+  resolved "https://registry.npmjs.org/immer/-/immer-10.0.3.tgz#a8de42065e964aa3edf6afc282dfc7f7f34ae3c9"
+  integrity sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A==
+
 immutable@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.0.tgz#eb1738f14ffb39fd068b1dbe1296117484dd34be"


### PR DESCRIPTION
Correct react immutable data philosophy and granular rendering.


Before:

When gpt is typing, all messages are re-rendered


https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/assets/41265413/ac52b626-a0f7-4aeb-b64e-52c585077aae

After:

Only render current message

https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/assets/41265413/aa02089b-150f-4ed2-a8fd-ffcdd1cc25f6

