### PR TITLE
feat:  Add auto-completion and cursor placement for code blocks.

### DIFF
--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -743,6 +743,23 @@ export function Settings() {
             </Select>
           </ListItem>
 
+          <ListItem
+            title={Locale.Settings.DisableCodeBlockAutoCompletion.Title}
+            subTitle={Locale.Settings.DisableCodeBlockAutoCompletion.SubTitle}
+          >
+            <input
+              type="checkbox"
+              checked={config.disableCodeBlockCompletion}
+              onChange={(e) =>
+                updateConfig(
+                  (config) =>
+                    (config.disableCodeBlockCompletion =
+                      e.currentTarget.checked),
+                )
+              }
+            ></input>
+          </ListItem>
+
           <ListItem title={Locale.Settings.Theme}>
             <Select
               value={config.theme}

--- a/app/locales/ar.ts
+++ b/app/locales/ar.ts
@@ -129,6 +129,10 @@ const ar: PartialLocaleType = {
       GoToUpdate: "التحديث",
     },
     SendKey: "مفتاح الإرسال",
+    DisableCodeBlockAutoCompletion: {
+      Title: "تعطيل الإكمال التلقائي لكتلة الكود",
+      SubTitle: "عند عدم التعطيل، سيكمل كتلة الكود ``` تلقائيًا",
+    },
     Theme: "السمة",
     TightBorder: "حدود ضيقة",
     SendPreviewBubble: {

--- a/app/locales/bn.ts
+++ b/app/locales/bn.ts
@@ -155,6 +155,10 @@ const bn: PartialLocaleType = {
       GoToUpdate: "Update",
     },
     SendKey: "প্রেরণ চাবি",
+    DisableCodeBlockAutoCompletion: {
+      Title: "কোড ব্লক অটো পূরণ নিষ্ক্রিয় করুন",
+      SubTitle: "নিষ্ক্রিয় না করলে, কোড ব্লক ``` স্বয়ংক্রিয়ভাবে পূরণ হবে",
+    },
     Theme: "থিম",
     TightBorder: "সঙ্গতি সীমা",
     SendPreviewBubble: {

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -170,6 +170,10 @@ const cn = {
       GoToUpdate: "前往更新",
     },
     SendKey: "发送键",
+    DisableCodeBlockAutoCompletion: {
+      Title: "禁用代码块自动补全",
+      SubTitle: "未禁用时，输入代码块 ``` 会自动补全",
+    },
     Theme: "主题",
     TightBorder: "无边框模式",
     SendPreviewBubble: {

--- a/app/locales/cs.ts
+++ b/app/locales/cs.ts
@@ -85,6 +85,10 @@ const cs: PartialLocaleType = {
       GoToUpdate: "Aktualizovat",
     },
     SendKey: "Odeslat klíč",
+    DisableCodeBlockAutoCompletion: {
+      Title: "Zakázat automatické dokončování bloku kódu",
+      SubTitle: "Pokud není zakázáno, blok kódu ``` se automaticky dokončí",
+    },
     Theme: "Téma",
     TightBorder: "Těsné ohraničení",
     SendPreviewBubble: {

--- a/app/locales/de.ts
+++ b/app/locales/de.ts
@@ -85,6 +85,11 @@ const de: PartialLocaleType = {
       GoToUpdate: "Aktualisieren",
     },
     SendKey: "Senden-Taste",
+    DisableCodeBlockAutoCompletion: {
+      Title: "Automatische Vervollständigung von Codeblöcken deaktivieren",
+      SubTitle:
+        "Wenn nicht deaktiviert, wird der Codeblock ``` automatisch vervollständigt",
+    },
     Theme: "Erscheinungsbild",
     TightBorder: "Enger Rahmen",
     SendPreviewBubble: {

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -172,6 +172,10 @@ const en: LocaleType = {
       GoToUpdate: "Update",
     },
     SendKey: "Send Key",
+    DisableCodeBlockAutoCompletion: {
+      Title: "Disable Code Block Auto Completion",
+      SubTitle: "When not disabled, entering code block ``` will auto complete",
+    },
     Theme: "Theme",
     TightBorder: "Tight Border",
     SendPreviewBubble: {

--- a/app/locales/es.ts
+++ b/app/locales/es.ts
@@ -85,6 +85,11 @@ const es: PartialLocaleType = {
       GoToUpdate: "Actualizar",
     },
     SendKey: "Tecla de envío",
+    DisableCodeBlockAutoCompletion: {
+      Title: "Desactivar autocompletado de bloque de código",
+      SubTitle:
+        "Cuando no está desactivado, al ingresar el bloque de código ``` se autocompletará",
+    },
     Theme: "Tema",
     TightBorder: "Borde ajustado",
     SendPreviewBubble: {

--- a/app/locales/fr.ts
+++ b/app/locales/fr.ts
@@ -129,6 +129,11 @@ const fr: PartialLocaleType = {
       GoToUpdate: "Mise à jour",
     },
     SendKey: "Clé d'envoi",
+    DisableCodeBlockAutoCompletion: {
+      Title: "Désactiver l'auto-complétion du bloc de code",
+      SubTitle:
+        "Lorsqu'elle n'est pas désactivée, l'entrée du bloc de code ``` sera auto-complétée",
+    },
     Theme: "Thème",
     TightBorder: "Bordure serrée",
     SendPreviewBubble: {

--- a/app/locales/id.ts
+++ b/app/locales/id.ts
@@ -194,6 +194,11 @@ const id: PartialLocaleType = {
       },
     },
     SendKey: "Kirim",
+    DisableCodeBlockAutoCompletion: {
+      Title: "Nonaktifkan Penyelesaian Otomatis Blok Kode",
+      SubTitle:
+        "Ketika tidak dinonaktifkan, memasukkan blok kode ``` akan dilengkapi secara otomatis",
+    },
     Theme: "Tema",
     TightBorder: "Batas Ketat",
     SendPreviewBubble: {
@@ -369,8 +374,8 @@ const id: PartialLocaleType = {
   },
   Exporter: {
     Description: {
-      Title: "Hanya pesan setelah menghapus konteks yang akan ditampilkan"
-    },  
+      Title: "Hanya pesan setelah menghapus konteks yang akan ditampilkan",
+    },
     Model: "Model",
     Messages: "Pesan",
     Topic: "Topik",

--- a/app/locales/it.ts
+++ b/app/locales/it.ts
@@ -85,6 +85,11 @@ const it: PartialLocaleType = {
       GoToUpdate: "Aggiorna",
     },
     SendKey: "Tasto invia",
+    DisableCodeBlockAutoCompletion: {
+      Title: "Disabilita il completamento automatico del blocco di codice",
+      SubTitle:
+        "Quando non disabilitato, l'inserimento del blocco di codice ``` si completerà automaticamente",
+    },
     Theme: "Tema",
     TightBorder: "Schermo intero",
     SendPreviewBubble: {

--- a/app/locales/jp.ts
+++ b/app/locales/jp.ts
@@ -136,6 +136,11 @@ const jp: PartialLocaleType = {
       GoToUpdate: "更新する",
     },
     SendKey: "送信キー",
+    DisableCodeBlockAutoCompletion: {
+      Title: "コードブロックの自動補完を無効にする",
+      SubTitle:
+        "無効にしない場合、コードブロック ``` の入力は自動的に補完されます",
+    },
     Theme: "テーマ",
     TightBorder: "ボーダーレスモード",
     SendPreviewBubble: {

--- a/app/locales/ko.ts
+++ b/app/locales/ko.ts
@@ -86,6 +86,10 @@ const ko: PartialLocaleType = {
       GoToUpdate: "업데이트",
     },
     SendKey: "전송 키",
+    DisableCodeBlockAutoCompletion: {
+      Title: "코드 블록 자동 완성 비활성화",
+      SubTitle: "비활성화하지 않으면 코드 블록 ``` 입력이 자동으로 완성됩니다",
+    },
     Theme: "테마",
     TightBorder: "조밀한 테두리",
     SendPreviewBubble: {

--- a/app/locales/no.ts
+++ b/app/locales/no.ts
@@ -80,6 +80,11 @@ const no: PartialLocaleType = {
       GoToUpdate: "Oppdater",
     },
     SendKey: "Send nøkkel",
+    DisableCodeBlockAutoCompletion: {
+      Title: "Deaktiver automatisk fullføring av kodeblokk",
+      SubTitle:
+        "Når det ikke er deaktivert, vil inntasting av kodeblokk ``` automatisk fullføres",
+    },
     Theme: "Tema",
     TightBorder: "Stram innramming",
     Prompt: {

--- a/app/locales/pt.ts
+++ b/app/locales/pt.ts
@@ -171,6 +171,11 @@ const pt: PartialLocaleType = {
       GoToUpdate: "Atualizar",
     },
     SendKey: "Tecla de Envio",
+    DisableCodeBlockAutoCompletion: {
+      Title: "Desativar auto-completar do bloco de código",
+      SubTitle:
+        "Quando não desativado, a entrada do bloco de código ``` será auto-completada",
+    },
     Theme: "Tema",
     TightBorder: "Borda Ajustada",
     SendPreviewBubble: {

--- a/app/locales/ru.ts
+++ b/app/locales/ru.ts
@@ -85,6 +85,11 @@ const ru: PartialLocaleType = {
       GoToUpdate: "Обновить",
     },
     SendKey: "Клавиша отправки",
+    DisableCodeBlockAutoCompletion: {
+      Title: "Отключить автоматическое дополнение блока кода",
+      SubTitle:
+        "Если не отключено, ввод блока кода ``` будет автоматически дополнен",
+    },
     Theme: "Тема",
     TightBorder: "Узкая граница",
     SendPreviewBubble: {

--- a/app/locales/sk.ts
+++ b/app/locales/sk.ts
@@ -173,6 +173,11 @@ const sk: PartialLocaleType = {
       GoToUpdate: "Aktualizovať",
     },
     SendKey: "Odoslať kľúč",
+    DisableCodeBlockAutoCompletion: {
+      Title: "Vypnúť automatické dopĺňanie kódového bloku",
+      SubTitle:
+        "Ak nie je vypnuté, zadanie kódového bloku ``` sa automaticky doplní",
+    },
     Theme: "Motív",
     TightBorder: "Tesný okraj",
     SendPreviewBubble: {

--- a/app/locales/tr.ts
+++ b/app/locales/tr.ts
@@ -85,6 +85,11 @@ const tr: PartialLocaleType = {
       GoToUpdate: "Güncelle",
     },
     SendKey: "Gönder Tuşu",
+    DisableCodeBlockAutoCompletion: {
+      Title: "Kod Bloğu Otomatik Tamamlamayı Devre Dışı Bırak",
+      SubTitle:
+        "Devre dışı bırakılmadığında, kod bloğu ``` otomatik olarak tamamlanır",
+    },
     Theme: "Tema",
     TightBorder: "Tam Ekran",
     SendPreviewBubble: {

--- a/app/locales/tw.ts
+++ b/app/locales/tw.ts
@@ -171,6 +171,10 @@ const tw = {
       GoToUpdate: "前往更新",
     },
     SendKey: "傳送鍵",
+    DisableCodeBlockAutoCompletion: {
+      Title: "禁用程式碼區塊自動完成",
+      SubTitle: "未禁用時，輸入程式碼區塊 ``` 會自動完成",
+    },
     Theme: "主題",
     TightBorder: "緊湊邊框",
     SendPreviewBubble: {
@@ -467,8 +471,8 @@ const tw = {
 
 type DeepPartial<T> = T extends object
   ? {
-    [P in keyof T]?: DeepPartial<T[P]>;
-  }
+      [P in keyof T]?: DeepPartial<T[P]>;
+    }
   : T;
 
 export type LocaleType = typeof tw;

--- a/app/locales/vi.ts
+++ b/app/locales/vi.ts
@@ -85,6 +85,11 @@ const vi: PartialLocaleType = {
       GoToUpdate: "Cập nhật",
     },
     SendKey: "Phím gửi",
+    DisableCodeBlockAutoCompletion: {
+      Title: "Vô hiệu hóa tự động hoàn thiện khối mã",
+      SubTitle:
+        "Khi không bị vô hiệu hóa, việc nhập khối mã ``` sẽ tự động hoàn thiện",
+    },
     Theme: "Theme",
     TightBorder: "Chế độ không viền",
     SendPreviewBubble: {

--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -58,6 +58,7 @@ export const DEFAULT_CONFIG = {
     enableInjectSystemPrompts: true,
     template: DEFAULT_INPUT_TEMPLATE,
   },
+  disableCodeBlockCompletion: false,
 };
 
 export type ChatConfig = typeof DEFAULT_CONFIG;


### PR DESCRIPTION
This PR introduces a new feature to the ChatGPT-Next-Web project that enhances the user experience when inputting code. The changes include:

Auto-completion for code blocks: After the user inputs three backticks, the application will now automatically close the code block with another three backticks. This saves time and reduces the likelihood of syntax errors.

Cursor placement in code blocks: Once the code block is auto-completed, the cursor will be automatically positioned within the code block area. This allows users to start coding immediately without needing to manually move the cursor.

New settings and multi-language support: Accompanying this feature is a new setting that allows users to enable or disable this auto-completion feature, providing flexibility based on user preference. Additionally, multi-language support has been added for this feature, ensuring a seamless user experience across different languages.

These enhancements are aimed at improving the overall usability of the code input interface, making it more intuitive and efficient for users to input code. Feedback and suggestions are welcome as we continue to improve and expand the project's features.

Please review and adjust as necessary.