### PR TITLE
Enhance File Export Functionality to Prevent Text File Encoding Issues

### DIFF
--- a/app/utils.ts
+++ b/app/utils.ts
@@ -8,10 +8,12 @@ export function trimTopic(topic: string) {
   // Fix an issue where double quotes still show in the Indonesian language
   // This will remove the specified punctuation from the end of the string
   // and also trim quotes from both the start and end if they exist.
-  return topic
-    // fix for gemini
-    .replace(/^["“”*]+|["“”*]+$/g, "")
-    .replace(/[，。！？”“"、,.!?*]*$/, "");
+  return (
+    topic
+      // fix for gemini
+      .replace(/^["“”*]+|["“”*]+$/g, "")
+      .replace(/[，。！？”“"、,.!?*]*$/, "")
+  );
 }
 
 export async function copyToClipboard(text: string) {
@@ -57,10 +59,9 @@ export async function downloadAs(text: string, filename: string) {
 
     if (result !== null) {
       try {
-        await window.__TAURI__.fs.writeBinaryFile(
-          result,
-          new Uint8Array([...text].map((c) => c.charCodeAt(0))),
-        );
+        const encoder = new TextEncoder();
+        const data = encoder.encode(text);
+        await window.__TAURI__.fs.writeBinaryFile(result, data);
         showToast(Locale.Download.Success);
       } catch (error) {
         showToast(Locale.Download.Failed);

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -41,7 +41,11 @@ export async function copyToClipboard(text: string) {
   }
 }
 
-export async function downloadAs(text: string, filename: string) {
+export async function downloadAs(
+  text: string,
+  filename: string,
+  isText = true,
+) {
   if (window.__TAURI__) {
     const result = await window.__TAURI__.dialog.save({
       defaultPath: `${filename}`,
@@ -59,9 +63,18 @@ export async function downloadAs(text: string, filename: string) {
 
     if (result !== null) {
       try {
-        const encoder = new TextEncoder();
-        const data = encoder.encode(text);
-        await window.__TAURI__.fs.writeBinaryFile(result, data);
+        if (isText) {
+          // text file download
+          const encoder = new TextEncoder();
+          const data = encoder.encode(text);
+          await window.__TAURI__.fs.writeBinaryFile(result, data);
+        } else {
+          // other fallback
+          await window.__TAURI__.fs.writeBinaryFile(
+            result,
+            new Uint8Array([...text].map((c) => c.charCodeAt(0))),
+          );
+        }
         showToast(Locale.Download.Success);
       } catch (error) {
         showToast(Locale.Download.Failed);


### PR DESCRIPTION
This PR addresses an issue with the Tauri-wrapped client where exported files such as masks, configurations, and other text files were experiencing encoding problems, resulting in gibberish or "garbage" characters in the output. The root cause was identified as a lack of proper handling for text and binary data during the file export process.

Changes:
1. Added a new parameter `isText` to the `downloadAs` function. This flag indicates whether the content to be downloaded is text or binary data. By default, it's set to `true`, assuming the data is text.

2. When `isText` is `true`, the function uses the TextEncoder API to properly encode the text data before writing it to a file. This prevents any encoding issues that were previously causing garbled output in the exported files.

3. When `isText` is `false`, the function treats the data as binary and writes it to the file as-is. This acts as a fallback mechanism to handle non-text data exports.

4. The changes are backward compatible and considerate of degradation scenarios.

This enhancement ensures a smoother user experience when exporting files using our Tauri client, with accurate data representation in the exported files. It also provides a more robust and flexible file export mechanism that can handle both text and binary data.

Please review and provide your feedback. Thanks!

related: https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/pull/3972