### PR TITLE
Fix EmojiPicker mobile width adaptation and update avatar clicking behavior

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -459,10 +459,6 @@ export function ChatActions(props: {
     if (!show) {
       props.setAttachImages([]);
       props.setUploading(false);
-    } else {
-      // 为visionModel时不附带历史消息
-      const newModelConfig = chatStore.currentSession().mask.modelConfig;
-      newModelConfig.historyMessageCount = 0;
     }
 
     // if current model is not available

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -459,6 +459,10 @@ export function ChatActions(props: {
     if (!show) {
       props.setAttachImages([]);
       props.setUploading(false);
+    } else {
+      // 为visionModel时不附带历史消息
+      const newModelConfig = chatStore.currentSession().mask.modelConfig;
+      newModelConfig.historyMessageCount = 0;
     }
 
     // if current model is not available

--- a/app/components/emoji.tsx
+++ b/app/components/emoji.tsx
@@ -21,6 +21,7 @@ export function AvatarPicker(props: {
 }) {
   return (
     <EmojiPicker
+      width={"100%"}
       lazyLoadEmojis
       theme={EmojiTheme.AUTO}
       getEmojiUrl={getEmojiUrl}

--- a/app/components/settings.module.scss
+++ b/app/components/settings.module.scss
@@ -5,6 +5,8 @@
 
 .avatar {
   cursor: pointer;
+  position: relative;
+  z-index: 1;
 }
 
 .edit-prompt-modal {

--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -693,7 +693,9 @@ export function Settings() {
             >
               <div
                 className={styles.avatar}
-                onClick={() => setShowEmojiPicker(true)}
+                onClick={() => {
+                  setShowEmojiPicker(!showEmojiPicker);
+                }}
               >
                 <Avatar avatar={config.avatar} />
               </div>

--- a/app/components/ui-lib.module.scss
+++ b/app/components/ui-lib.module.scss
@@ -14,17 +14,24 @@
 
 .popover-content {
   position: absolute;
+  width: 350px;
   animation: slide-in 0.3s ease;
   right: 0;
   top: calc(100% + 10px);
 }
-
+@media screen and (max-width: 600px) {
+  .popover-content {
+    width: auto;
+  }
+}
 .popover-mask {
   position: fixed;
   top: 0;
   left: 0;
   width: 100vw;
   height: 100vh;
+  background-color: rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(5px);
 }
 
 .list-item {

--- a/app/components/ui-lib.tsx
+++ b/app/components/ui-lib.tsx
@@ -26,10 +26,10 @@ export function Popover(props: {
     <div className={styles.popover}>
       {props.children}
       {props.open && (
-        <div className={styles["popover-content"]}>
-          <div className={styles["popover-mask"]} onClick={props.onClose}></div>
-          {props.content}
-        </div>
+        <div className={styles["popover-mask"]} onClick={props.onClose}></div>
+      )}
+      {props.open && (
+        <div className={styles["popover-content"]}>{props.content}</div>
       )}
     </div>
   );


### PR DESCRIPTION
修复在移动端进行修改头像的时候，EmojiPicker超出屏幕外导致不好选的问题，并添加背景颜色，修改后后如下：
![image](https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/assets/112751823/0cb0e8e6-b646-4a7a-a955-d3bee6d6e525)
