### PR TITLE
Refactor useScrollToBottom Hook (auto-scroll fix)

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -387,28 +387,28 @@ function useScrollToBottom(
   scrollRef: RefObject<HTMLDivElement>,
   detach: boolean = false,
 ) {
+  // for auto-scroll
+  
   const [autoScroll, setAutoScroll] = useState(true);
-
+  function scrollDomToBottom() {
+    if (!autoScroll) {
+      setAutoScroll(true);
+    }
+    const dom = scrollRef.current;
+    if (dom) {
+      dom.scrollTo(0, dom.scrollHeight);
+    }
+  }
+  
+  // auto scroll
   useEffect(() => {
     if (autoScroll && !detach) {
       const dom = scrollRef.current;
       if (dom) {
-        requestAnimationFrame(() => {
-          dom.scrollTo(0, dom.scrollHeight);
-        });
+        dom.scrollTo(0, dom.scrollHeight);
       }
     }
   }, [autoScroll, detach, scrollRef]);
-
-  function scrollDomToBottom() {
-    setAutoScroll(true);
-    const dom = scrollRef.current;
-    if (dom) {
-      requestAnimationFrame(() => {
-        dom.scrollTo(0, dom.scrollHeight);
-      });
-    }
-  }
 
   return {
     scrollRef,

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -398,7 +398,7 @@ function useScrollToBottom(
         });
       }
     }
-  }, [autoScroll, detach]);
+  }, [autoScroll, detach, scrollRef]);
 
   function scrollDomToBottom() {
     setAutoScroll(true);

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -393,7 +393,9 @@ function useScrollToBottom(
     if (autoScroll && !detach) {
       const dom = scrollRef.current;
       if (dom) {
-        dom.scrollTo(0, dom.scrollHeight);
+        requestAnimationFrame(() => {
+          dom.scrollTo(0, dom.scrollHeight);
+        });
       }
     }
   }, [autoScroll, detach]);
@@ -402,7 +404,9 @@ function useScrollToBottom(
     setAutoScroll(true);
     const dom = scrollRef.current;
     if (dom) {
-      dom.scrollTo(0, dom.scrollHeight);
+      requestAnimationFrame(() => {
+        dom.scrollTo(0, dom.scrollHeight);
+      });
     }
   }
 

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -396,7 +396,7 @@ function useScrollToBottom(
         dom.scrollTo(0, dom.scrollHeight);
       }
     }
-  }, [autoScroll, detach, scrollRef]);
+  }, [autoScroll, detach]);
 
   function scrollDomToBottom() {
     setAutoScroll(true);

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -387,25 +387,24 @@ function useScrollToBottom(
   scrollRef: RefObject<HTMLDivElement>,
   detach: boolean = false,
 ) {
-  // for auto-scroll
-
   const [autoScroll, setAutoScroll] = useState(true);
-  function scrollDomToBottom() {
-    const dom = scrollRef.current;
-    if (dom) {
-      requestAnimationFrame(() => {
-        setAutoScroll(true);
-        dom.scrollTo(0, dom.scrollHeight);
-      });
-    }
-  }
 
-  // auto scroll
   useEffect(() => {
     if (autoScroll && !detach) {
-      scrollDomToBottom();
+      const dom = scrollRef.current;
+      if (dom) {
+        dom.scrollTo(0, dom.scrollHeight);
+      }
     }
-  });
+  }, [autoScroll, detach, scrollRef]);
+
+  function scrollDomToBottom() {
+    setAutoScroll(true);
+    const dom = scrollRef.current;
+    if (dom) {
+      dom.scrollTo(0, dom.scrollHeight);
+    }
+  }
 
   return {
     scrollRef,

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -388,7 +388,7 @@ function useScrollToBottom(
   detach: boolean = false,
 ) {
   // for auto-scroll
-  
+
   const [autoScroll, setAutoScroll] = useState(true);
   function scrollDomToBottom() {
     if (!autoScroll) {
@@ -399,7 +399,7 @@ function useScrollToBottom(
       dom.scrollTo(0, dom.scrollHeight);
     }
   }
-  
+
   // auto scroll
   useEffect(() => {
     if (autoScroll && !detach) {


### PR DESCRIPTION
- Removed `requestAnimationFrame` from `scrollDomToBottom` function, simplifying the scroll logic.
- Updated `scrollDomToBottom` to check `autoScroll` state before setting it to `true`, reducing unnecessary state updates.
- Added dependencies `[autoScroll, detach, scrollRef]` to `useEffect` to ensure it only runs when these values change, improving performance and preventing unnecessary executions.
- Removed redundant `autoScroll` state setting within `useEffect` since it's already handled in `scrollDomToBottom`.