### PR TITLE
feat(chat.tsx): 解决 safari 浏览器下和 mac app 下中文输入法组词时按下回车导致直接提交的问题

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -205,23 +205,23 @@ function useSubmitHandler() {
     const onCompositionStart = () => {
       isComposing.current = true;
     };
-    const onCompositionEnd = () => {
-      isComposing.current = false;
-    };
 
     window.addEventListener("compositionstart", onCompositionStart);
-    window.addEventListener("compositionend", onCompositionEnd);
 
     return () => {
       window.removeEventListener("compositionstart", onCompositionStart);
-      window.removeEventListener("compositionend", onCompositionEnd);
     };
   }, []);
 
   const shouldSubmit = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key !== "Enter") return false;
-    if (e.key === "Enter" && (e.nativeEvent.isComposing || isComposing.current))
+    if (
+      e.key === "Enter" &&
+      (e.nativeEvent.isComposing || isComposing.current)
+    ) {
+      isComposing.current = false;
       return false;
+    }
     return (
       (config.submitKey === SubmitKey.AltEnter && e.altKey) ||
       (config.submitKey === SubmitKey.CtrlEnter && e.ctrlKey) ||
@@ -1100,11 +1100,13 @@ function _Chat() {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-  
+
   const handlePaste = useCallback(
     async (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
       const currentModel = chatStore.currentSession().mask.modelConfig.model;
-      if(!isVisionModel(currentModel)){return;}
+      if (!isVisionModel(currentModel)) {
+        return;
+      }
       const items = (event.clipboardData || window.clipboardData).items;
       for (const item of items) {
         if (item.kind === "file" && item.type.startsWith("image/")) {


### PR DESCRIPTION
当我在 macos 上使用 ChatNext APP 时，发现中文输入法下，正在输入中文的时候，按下回车就自动提交了，但是用 chrome 打开 web 端就没问题，后面发现 app 用的浏览器内核是 safari，用 safari 打开 web 端复现了这个问题，因此我直接下载源码进行了 bug 的修复