### PR TITLE
chore: specify yarn 1 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,5 +63,6 @@
   },
   "resolutions": {
     "lint-staged/yaml": "^2.2.2"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
Certain Continuous Integration (CI) systems, such as [Cloudflare Pages](https://pages.cloudflare.com/), use the latest version of Yarn by default, whereas `ChatGPT-Next-Web` utilizes Yarn 1.

This Pull Request (PR) adds the [`packageManager` field](https://nodejs.org/api/packages.html#packagemanager) to the `package.json` file, specifying that Yarn 1 should be used. This enables Cloudflare Pages to automatically install and select Yarn 1 for the build process.

This also simplifies the process for contributors who use [corepack](https://nodejs.org/api/corepack.html), enabling them to switch their package manager automatically.