### PR TITLE
Fix "Enter" bug

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -219,6 +219,8 @@ function useSubmitHandler() {
   }, []);
 
   const shouldSubmit = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Fix Chinese input method "Enter" on Safari
+    if (e.keyCode == 229) return false;
     if (e.key !== "Enter") return false;
     if (e.key === "Enter" && (e.nativeEvent.isComposing || isComposing.current))
       return false;


### PR DESCRIPTION
Fix Chinese input method "Enter" on Safari #4297 