### PR TITLE
Fix splicing at the end of the list when the model list changes in the middle of the constant definition，and correcting a error word

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -463,8 +463,8 @@ export function ChatActions(props: {
 
     // if current model is not available
     // switch to first available model
-    const isUnavaliableModel = !models.some((m) => m.name === currentModel);
-    if (isUnavaliableModel && models.length > 0) {
+    const isUnavailableModel = !models.some((m) => m.name === currentModel);
+    if (isUnavailableModel && models.length > 0) {
       const nextModel = models[0].name as ModelType;
       chatStore.updateCurrentSession(
         (session) => (session.mask.modelConfig.model = nextModel),
@@ -1100,11 +1100,13 @@ function _Chat() {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-  
+
   const handlePaste = useCallback(
     async (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
       const currentModel = chatStore.currentSession().mask.modelConfig.model;
-      if(!isVisionModel(currentModel)){return;}
+      if (!isVisionModel(currentModel)) {
+        return;
+      }
       const items = (event.clipboardData || window.clipboardData).items;
       for (const item of items) {
         if (item.kind === "file" && item.type.startsWith("image/")) {

--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -97,7 +97,6 @@ export const ModalConfigValidator = {
     return limitNumber(x, 0, 1, 1);
   },
 };
-console.log("config", DEFAULT_CONFIG);
 
 export const useAppConfig = createPersistStore(
   { ...DEFAULT_CONFIG },

--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -97,6 +97,7 @@ export const ModalConfigValidator = {
     return limitNumber(x, 0, 1, 1);
   },
 };
+console.log("config", DEFAULT_CONFIG);
 
 export const useAppConfig = createPersistStore(
   { ...DEFAULT_CONFIG },
@@ -109,14 +110,7 @@ export const useAppConfig = createPersistStore(
       if (!newModels || newModels.length === 0) {
         return;
       }
-
-      const oldModels = get().models;
       const modelMap: Record<string, LLMModel> = {};
-
-      for (const model of oldModels) {
-        model.available = false;
-        modelMap[model.name] = model;
-      }
 
       for (const model of newModels) {
         model.available = true;


### PR DESCRIPTION
修复当模型列表更改在常量定义的中间时，会拼接在列表尾部，比如我旧的DEFAULT_MODELS有[gpt4,gpt4-03,gpt3]，此时用户已经访问过本项目，并且存储了旧的模型列表，当我在更新中给新的DEFAULT_MODELS设置为[gpt4,gpt4-03,gpt4-06,gpt3]时，用户重新访问本项目时，新的模型会拼接在列表底部，情况如下例子：
![image](https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/assets/112751823/3e7ab275-6469-439e-9c8a-f01f39847c9c)
这样让用户列表变的混乱起来了
故删除相应的oldModels处理，直接使用获取到的newModels。
其他：更正了一个单词拼写错误