### PR TITLE
Fix: Handle empty server response in API call

### DIFF
--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -151,6 +151,9 @@ export class ChatGPTApi implements LLMApi {
           if (finished || controller.signal.aborted) {
             responseText += remainText;
             console.log("[Response Animation] finished");
+            if (responseText?.length === 0) {
+              options.onError?.(new Error("empty response from server"));
+            }
             return;
           }
 


### PR DESCRIPTION
在这次提交中，我针对本地使用的模型在处理问答提交时可能出现的问题进行了改善。具体场景是：当用户提交一个问题后，由于模型原因已经结束了但是未能返回任何信息时，界面会持续显示加载状态，而无任何反馈给用户。为了解决这一问题，本次提交增加了对已结束但返回结果长度为零情况的处理逻辑