### PR TITLE
refactor/chore: define client config during build time

### DIFF
--- a/app/components/home.tsx
+++ b/app/components/home.tsx
@@ -112,7 +112,8 @@ const loadAsyncGoogleFont = () => {
   const proxyFontUrl = "/google-fonts";
   const remoteFontUrl = "https://fonts.googleapis.com";
   const googleFontUrl =
-    getClientConfig()?.buildMode === "export" ? remoteFontUrl : proxyFontUrl;
+    process.env.BUILD_MODE === "export" ? remoteFontUrl : proxyFontUrl;
+
   linkEl.rel = "stylesheet";
   linkEl.href =
     googleFontUrl +

--- a/app/config/build.ts
+++ b/app/config/build.ts
@@ -7,7 +7,6 @@ export const getBuildConfig = () => {
     );
   }
 
-  const buildMode = process.env.BUILD_MODE ?? "standalone";
   const isApp = !!process.env.BUILD_APP;
   const version = "v" + tauriConfig.package.version;
 
@@ -36,7 +35,6 @@ export const getBuildConfig = () => {
   return {
     version,
     ...commitInfo,
-    buildMode,
     isApp,
   };
 };

--- a/app/store/access.ts
+++ b/app/store/access.ts
@@ -12,7 +12,7 @@ import { ensure } from "../utils/clone";
 let fetchState = 0; // 0 not fetch, 1 fetching, 2 done
 
 const DEFAULT_OPENAI_URL =
-  getClientConfig()?.buildMode === "export"
+  process.env.BUILD_MODE === "export"
     ? DEFAULT_API_HOST + "/api/proxy/openai"
     : ApiPath.OpenAI;
 
@@ -80,7 +80,7 @@ export const useAccessStore = createPersistStore(
       );
     },
     fetch() {
-      if (fetchState > 0 || getClientConfig()?.buildMode === "export") return;
+      if (fetchState > 0 || process.env.BUILD_MODE === "export") return;
       fetchState = 1;
       fetch("/api/config", {
         method: "post",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -36,8 +36,8 @@ const nextConfig = {
    * - https://github.com/vercel/next.js/blob/08a92e0aa589e9220b0e740594c39846c69ef308/packages/next/src/build/webpack/plugins/define-env-plugin.ts#L146
    */
   env: {
-    // This is avaliable as process.env.buildMode
-    BUILD_MODE: mode,
+    // This is avaliable as process.env.BUILD_MODE
+    BUILD_MODE: JSON.stringify('mode'),
   },
   output: mode,
   images: {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -26,6 +26,19 @@ const nextConfig = {
 
     return config;
   },
+  /**
+   * Next.js supports inline public environment variables in next.config.js
+   *
+   * https://nextjs.org/docs/app/api-reference/next-config-js/env
+   *
+   * Next.js implements this using webpack.DefinePlugin:
+   * - https://github.com/vercel/next.js/blob/08a92e0aa589e9220b0e740594c39846c69ef308/packages/next/src/build/webpack/plugins/define-env-plugin.ts#L76
+   * - https://github.com/vercel/next.js/blob/08a92e0aa589e9220b0e740594c39846c69ef308/packages/next/src/build/webpack/plugins/define-env-plugin.ts#L146
+   */
+  env: {
+    // This is avaliable as process.env.buildMode
+    BUILD_MODE: mode,
+  },
   output: mode,
   images: {
     unoptimized: mode === "export",


### PR DESCRIPTION
The `buildMode` is accessible during build time, and we therefore directly inline it in the code, as shown:

```tsx
const proxyFontUrl = "/google-fonts";
const remoteFontUrl = "https://fonts.googleapis.com";
const googleFontUrl = process.env.BUILD_MODE === "export" ? remoteFontUrl : proxyFontUrl;
```

Next.js will inline the actual value during the build:

```tsx
const proxyFontUrl = "/google-fonts";
const remoteFontUrl = "https://fonts.googleapis.com";
const googleFontUrl = "standalone" === "export" ? remoteFontUrl : proxyFontUrl;

// And here is the final output after the minification
const googleFontUrl = "/google-fonts"
```

Thus we can reduce the bundle size and simplify the code.

See also:

- Next.js `env` in `next.config.js`: https://nextjs.org/docs/app/api-reference/next-config-js/env
- Next.js reading `env` in `next.config.js` and passing it to `webpack.DefinePlugin`:
  - https://github.com/vercel/next.js/blob/08a92e0aa589e9220b0e740594c39846c69ef308/packages/next/src/build/webpack/plugins/define-env-plugin.ts#L76
  -  https://github.com/vercel/next.js/blob/08a92e0aa589e9220b0e740594c39846c69ef308/packages/next/src/build/webpack/plugins/define-env-plugin.ts#L146