### PR TITLE
optional max_tokens

### DIFF
--- a/app/client/api.ts
+++ b/app/client/api.ts
@@ -34,6 +34,7 @@ export interface LLMConfig {
   stream?: boolean;
   presence_penalty?: number;
   frequency_penalty?: number;
+  useMaxTokens?: boolean;
 }
 
 export interface ChatOptions {

--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -106,8 +106,7 @@ export class ChatGPTApi implements LLMApi {
       presence_penalty: modelConfig.presence_penalty,
       frequency_penalty: modelConfig.frequency_penalty,
       top_p: modelConfig.top_p,
-      // max_tokens: Math.max(modelConfig.max_tokens, 1024),
-      // Please do not ask me why not send max_tokens, no reason, this param is just shit, I dont want to explain anymore.
+      max_tokens: modelConfig.useMaxTokens ? modelConfig.max_tokens : undefined,
     };
 
     // add max_tokens to vision model

--- a/app/components/model-config.tsx
+++ b/app/components/model-config.tsx
@@ -72,25 +72,38 @@ export function ModelConfigList(props: {
           }}
         ></InputRange>
       </ListItem>
-      <ListItem
-        title={Locale.Settings.MaxTokens.Title}
-        subTitle={Locale.Settings.MaxTokens.SubTitle}
-      >
+      <ListItem title={"Use Max Tokens"}>
         <input
-          type="number"
-          min={1024}
-          max={512000}
-          value={props.modelConfig.max_tokens}
+          type="checkbox"
+          checked={props.modelConfig.useMaxTokens}
           onChange={(e) =>
             props.updateConfig(
-              (config) =>
-                (config.max_tokens = ModalConfigValidator.max_tokens(
-                  e.currentTarget.valueAsNumber,
-                )),
+              (config) => (config.useMaxTokens = e.currentTarget.checked),
             )
           }
         ></input>
       </ListItem>
+      {props.modelConfig.useMaxTokens && (
+        <ListItem
+          title={Locale.Settings.MaxTokens.Title}
+          subTitle={Locale.Settings.MaxTokens.SubTitle}
+        >
+          <input
+            type="number"
+            min={1}
+            max={32768}
+            value={props.modelConfig.max_tokens}
+            onChange={(e) =>
+              props.updateConfig(
+                (config) =>
+                  (config.max_tokens = ModalConfigValidator.max_tokens(
+                    e.currentTarget.valueAsNumber,
+                  )),
+              )
+            }
+          ></input>
+        </ListItem>
+      )}
 
       {props.modelConfig.model.startsWith("gemini") ? null : (
         <>

--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -49,7 +49,7 @@ export const DEFAULT_CONFIG = {
     model: "gpt-3.5-turbo" as ModelType,
     temperature: 0.5,
     top_p: 1,
-    max_tokens: 4000,
+    max_tokens: 2048,
     presence_penalty: 0,
     frequency_penalty: 0,
     sendMemory: true,
@@ -57,6 +57,7 @@ export const DEFAULT_CONFIG = {
     compressMessageLengthThreshold: 1000,
     enableInjectSystemPrompts: true,
     template: DEFAULT_INPUT_TEMPLATE,
+    useMaxTokens: false,
   },
 };
 


### PR DESCRIPTION
Use a checkbox to optionally enable the use of max_tokens instead of having it disabled. This feature is useful for OpenAI models, as well as models from OpenRouter and other platforms.
I've set the default to `2048` for smaller context models (4k); however, `4096` is the preferred setting for newer models from OpenAI and Anthropic. Despite these models supporting much larger contexts, their output is capped at `4096`.