### PR TITLE
Gemini will generate the request address based on the selected model name and supports Gemini 1.5 Pro (gemini-1.5-pro-latest).

### DIFF
--- a/app/client/platforms/google.ts
+++ b/app/client/platforms/google.ts
@@ -112,15 +112,15 @@ export class GeminiProApi implements LLMApi {
     options.onController?.(controller);
     try {
       let googleChatPath = visionModel
-        ? Google.VisionChatPath
-        : Google.ChatPath;
+        ? Google.ChatPath(modelConfig.model)
+        : Google.VisionChatPath(modelConfig.model);
       let chatPath = this.path(googleChatPath);
 
       // let baseUrl = accessStore.googleUrl;
 
       if (!baseUrl) {
         baseUrl = isApp
-          ? DEFAULT_API_HOST + "/api/proxy/google/" + googleChatPath
+          ? DEFAULT_API_HOST + "/api/proxy/google/" + Google.ChatPath(modelConfig.model)
           : chatPath;
       }
 

--- a/app/constant.ts
+++ b/app/constant.ts
@@ -25,6 +25,7 @@ export enum Path {
 export enum ApiPath {
   Cors = "",
   OpenAI = "/api/openai",
+  Google = "/api/google",
 }
 
 export enum SlotID {
@@ -87,10 +88,8 @@ export const Azure = {
 
 export const Google = {
   ExampleEndpoint: "https://generativelanguage.googleapis.com/",
-  ChatPath: "v1beta/models/gemini-pro:generateContent",
-  VisionChatPath: "v1beta/models/gemini-pro-vision:generateContent",
-
-  // /api/openai/v1/chat/completions
+  ChatPath: (modelName: string) => `v1beta/models/${modelName}:generateContent`,
+  VisionChatPath: (modelName: string) => `v1beta/models/${modelName}:generateContent`,
 };
 
 export const DEFAULT_INPUT_TEMPLATE = `{{input}}`; // input / time / model / lang
@@ -115,6 +114,7 @@ export const KnowledgeCutOffDate: Record<string, string> = {
   // After improvements,
   // it's now easier to add "KnowledgeCutOffDate" instead of stupid hardcoding it, as was done previously.
   "gemini-pro": "2023-12",
+  "gemini-pro-vision": "2023-12",
 };
 
 export const DEFAULT_MODELS = [
@@ -272,7 +272,16 @@ export const DEFAULT_MODELS = [
     },
   },
   {
-    name: "gemini-pro",
+    name: "gemini-1.0-pro",
+    available: true,
+    provider: {
+      id: "google",
+      providerName: "Google",
+      providerType: "google",
+    },
+  },
+  {
+    name: "gemini-1.5-pro-latest",
     available: true,
     provider: {
       id: "google",


### PR DESCRIPTION
This submission can be adapted to future models.
![photo](https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/assets/36145660/ac4f1dd9-c2c0-4728-bf75-18fd426e3b4b)