### PR TITLE
feat: Display model name with message date in chat

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -1441,7 +1441,7 @@ function _Chat() {
                   <div className={styles["chat-message-action-date"]}>
                     {isContext
                       ? Locale.Chat.IsContext
-                      : message.date.toLocaleString()}
+                      : `${message.model ? `${message.model} | ` : ""}${message.date.toLocaleString()}`}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
**Description:**
This PR adds the model name to the message date in the chat message component, displaying it for previous messages as well.

**Changes:**
- Modified the `chat-message-action-date` element to display the model name (if available) along with the message date.

**Motivation:**
Providing the model name alongside the message date can be helpful for users to understand which model was used to generate the message, including for previous messages before this change.