### PR TITLE
fix: `Invalid URL` thrown during WebDAV sync

### DIFF
--- a/app/utils/cloud/webdav.ts
+++ b/app/utils/cloud/webdav.ts
@@ -77,7 +77,7 @@ export function createWebDavClient(store: SyncStore) {
         proxyUrl = location.origin;
       }
       let url;
-      if (proxyUrl.length > 0 || proxyUrl === "/") {
+      if (proxyUrl.length > 0) {
         let u = new URL(proxyUrl + "/api/webdav/" + path);
         // add query params
         u.searchParams.append("endpoint", config.endpoint);

--- a/app/utils/cloud/webdav.ts
+++ b/app/utils/cloud/webdav.ts
@@ -70,6 +70,9 @@ export function createWebDavClient(store: SyncStore) {
       if (proxyUrl === "") {
         proxyUrl = (() => {let url = new URL(location.href); url.hash = ''; url.search = ''; return url.href.substring(0, url.href.length-1)})();
       }
+      if (proxyUrl.endsWith("/")) {
+        proxyUrl = proxyUrl.slice(0, -1);
+      }
       let u = new URL(proxyUrl + "/api/webdav/" + path);
       // add query params
       u.searchParams.append("endpoint", config.endpoint);

--- a/app/utils/cloud/webdav.ts
+++ b/app/utils/cloud/webdav.ts
@@ -70,19 +70,13 @@ export function createWebDavClient(store: SyncStore) {
         path = path.slice(1);
       }
       
-      if (proxyUrl === "/") {
+      if (proxyUrl === "") {
         proxyUrl = location.origin;
       }
-      let url;
-      if (proxyUrl.length > 0) {
-        let u = new URL(proxyUrl + "/api/webdav/" + path);
-        // add query params
-        u.searchParams.append("endpoint", config.endpoint);
-        url = u.toString();
-      } else {
-        url = "/api/upstash/" + path + "?endpoint=" + config.endpoint;
-      }
-      return url;
+      let u = new URL(proxyUrl + "/api/webdav/" + path);
+      // add query params
+      u.searchParams.append("endpoint", config.endpoint);
+      return u.toString();
     },
   };
 }

--- a/app/utils/cloud/webdav.ts
+++ b/app/utils/cloud/webdav.ts
@@ -68,7 +68,7 @@ export function createWebDavClient(store: SyncStore) {
       }
       
       if (proxyUrl === "") {
-        proxyUrl = location.origin;
+        proxyUrl = (() => {let url = new URL(location.href); url.hash = ''; url.search = ''; return url.href.substring(0, url.href.length-1)})();
       }
       let u = new URL(proxyUrl + "/api/webdav/" + path);
       // add query params

--- a/app/utils/cloud/webdav.ts
+++ b/app/utils/cloud/webdav.ts
@@ -73,7 +73,9 @@ export function createWebDavClient(store: SyncStore) {
       if (proxyUrl.length > 0 && !proxyUrl.endsWith("/")) {
         proxyUrl += "/";
       }
-
+      if (proxyUrl === "/") {
+        proxyUrl = location.origin;
+      }
       let url;
       if (proxyUrl.length > 0 || proxyUrl === "/") {
         let u = new URL(proxyUrl + "/api/webdav/" + path);

--- a/app/utils/cloud/webdav.ts
+++ b/app/utils/cloud/webdav.ts
@@ -69,10 +69,7 @@ export function createWebDavClient(store: SyncStore) {
       if (path.startsWith("/")) {
         path = path.slice(1);
       }
-
-      if (proxyUrl.length > 0 && !proxyUrl.endsWith("/")) {
-        proxyUrl += "/";
-      }
+      
       if (proxyUrl === "/") {
         proxyUrl = location.origin;
       }


### PR DESCRIPTION
fix #4335 and #4503
Tested in docker 