### PR TITLE
add timezone in system prompts

### DIFF
--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -120,7 +120,7 @@ function fillTemplateWith(input: string, modelConfig: ModelConfig) {
     ServiceProvider: serviceProvider,
     cutoff,
     model: modelConfig.model,
-    time: new Date().toLocaleString(),
+    time: new Date().toString(),
     lang: getLang(),
     input: input,
   };


### PR DESCRIPTION
**以前的效果（提问的时间是北京时间2024年4月12日23:00，但gpt误以为是utc时间）：**
![image](https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/assets/28617777/4bb4ae84-aa44-4dcc-b7b7-b0768e2b08f2)



**修改后的效果：**
![image](https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/assets/28617777/7942930f-b5fc-4b03-996f-b63b2a15fa1f)
