### PR TITLE
perf: avoid read localStorage on every render

### DIFF
--- a/app/components/mask.tsx
+++ b/app/components/mask.tsx
@@ -405,7 +405,7 @@ export function MaskPage() {
   const chatStore = useChatStore();
 
   const [filterLang, setFilterLang] = useState<Lang | undefined>(
-    localStorage.getItem("Mask-language") as Lang | undefined,
+    () => localStorage.getItem("Mask-language") as Lang | undefined,
   );
   useEffect(() => {
     if (filterLang) {


### PR DESCRIPTION
Prevents reading `localStorage` every time the `<MaskPage />` renders.