### PR TITLE
chore: summarization logic regarding Anthropic

### DIFF
--- a/app/constant.ts
+++ b/app/constant.ts
@@ -122,6 +122,7 @@ Latex block: $$e=mc^2$$
 
 export const SUMMARIZE_MODEL = "gpt-3.5-turbo";
 export const GEMINI_SUMMARIZE_MODEL = "gemini-pro";
+export const ANTHROPIC_SUMMARIZE_MODEL = "claude-3-haiku-20240307"
 
 export const KnowledgeCutOffDate: Record<string, string> = {
   default: "2021-09",

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -13,6 +13,7 @@ import {
   StoreKey,
   SUMMARIZE_MODEL,
   GEMINI_SUMMARIZE_MODEL,
+  ANTHROPIC_SUMMARIZE_MODEL,
 } from "../constant";
 import { ClientApi, RequestMessage, MultimodalContent } from "../client/api";
 import { ChatControllerPool } from "../client/controller";
@@ -91,6 +92,9 @@ function getSummarizeModel(currentModel: string) {
   }
   if (currentModel.startsWith("gemini-pro")) {
     return GEMINI_SUMMARIZE_MODEL;
+  }
+  if (currentModel.startsWith("claude")){
+    return ANTHROPIC_SUMMARIZE_MODEL;
   }
   return currentModel;
 }


### PR DESCRIPTION
Users using the Claude model provided by Anthropic may find that they are using the same summary model as the dialogue model, which generally results in additional costs.

This PR adds summary model judgement logic that was missing when using the Claude model, and by default the user's dialogue will be summarised using the haiku, which is the least costly one.

Of course, if the user wishes to use a different summarisation model, they can change it themselves.
`ANTHROPIC_SUMMARIZE_MODEL`.