### PR TITLE
Support a way to define default model by adding DEFAULT_MODEL env.

### DIFF
--- a/app/api/config/route.ts
+++ b/app/api/config/route.ts
@@ -13,6 +13,7 @@ const DANGER_CONFIG = {
   hideBalanceQuery: serverConfig.hideBalanceQuery,
   disableFastLink: serverConfig.disableFastLink,
   customModels: serverConfig.customModels,
+  defaultModel: serverConfig.defaultModel,
 };
 
 declare global {

--- a/app/config/server.ts
+++ b/app/config/server.ts
@@ -21,6 +21,7 @@ declare global {
       ENABLE_BALANCE_QUERY?: string; // allow user to query balance or not
       DISABLE_FAST_LINK?: string; // disallow parse settings from url or not
       CUSTOM_MODELS?: string; // to control custom models
+      DEFAULT_MODEL?: string; // to cnntrol default model in every new chat window
 
       // azure only
       AZURE_URL?: string; // https://{azure-url}/openai/deployments/{deploy-name}
@@ -59,12 +60,14 @@ export const getServerSideConfig = () => {
 
   const disableGPT4 = !!process.env.DISABLE_GPT4;
   let customModels = process.env.CUSTOM_MODELS ?? "";
+  let defaultModel = process.env.DEFAULT_MODEL ?? "";
 
   if (disableGPT4) {
     if (customModels) customModels += ",";
     customModels += DEFAULT_MODELS.filter((m) => m.name.startsWith("gpt-4"))
       .map((m) => "-" + m.name)
       .join(",");
+    if (defaultModel.startsWith("gpt-4")) defaultModel = "";
   }
 
   const isAzure = !!process.env.AZURE_URL;
@@ -116,6 +119,7 @@ export const getServerSideConfig = () => {
     hideBalanceQuery: !process.env.ENABLE_BALANCE_QUERY,
     disableFastLink: !!process.env.DISABLE_FAST_LINK,
     customModels,
+    defaultModel,
     whiteWebDevEndpoints,
   };
 };

--- a/app/store/access.ts
+++ b/app/store/access.ts
@@ -8,6 +8,7 @@ import { getHeaders } from "../client/api";
 import { getClientConfig } from "../config/client";
 import { createPersistStore } from "../utils/store";
 import { ensure } from "../utils/clone";
+import { DEFAULT_CONFIG } from "./config";
 
 let fetchState = 0; // 0 not fetch, 1 fetching, 2 done
 
@@ -48,6 +49,7 @@ const DEFAULT_ACCESS_STATE = {
   disableGPT4: false,
   disableFastLink: false,
   customModels: "",
+  defaultModel: "",
 };
 
 export const useAccessStore = createPersistStore(
@@ -100,6 +102,13 @@ export const useAccessStore = createPersistStore(
         },
       })
         .then((res) => res.json())
+        .then((res) => {
+          // Set default model from env request
+          let defaultModel = res.defaultModel ?? "";
+          DEFAULT_CONFIG.modelConfig.model =
+            defaultModel !== "" ? defaultModel : "gpt-3.5-turbo";
+          return res;
+        })
         .then((res: DangerConfig) => {
           console.log("[Config] got config from server", res);
           set(() => ({ ...res }));

--- a/app/utils/hooks.ts
+++ b/app/utils/hooks.ts
@@ -1,14 +1,15 @@
 import { useMemo } from "react";
 import { useAccessStore, useAppConfig } from "../store";
-import { collectModels } from "./model";
+import { collectModels, collectModelsWithDefaultModel } from "./model";
 
 export function useAllModels() {
   const accessStore = useAccessStore();
   const configStore = useAppConfig();
   const models = useMemo(() => {
-    return collectModels(
+    return collectModelsWithDefaultModel(
       configStore.models,
       [configStore.customModels, accessStore.customModels].join(","),
+      accessStore.defaultModel,
     );
   }, [accessStore.customModels, configStore.customModels, configStore.models]);
 

--- a/app/utils/model.ts
+++ b/app/utils/model.ts
@@ -1,5 +1,11 @@
 import { LLMModel } from "../client/api";
 
+const customProvider = (modelName: string) => ({
+  id: modelName,
+  providerName: "",
+  providerType: "custom",
+});
+
 export function collectModelTable(
   models: readonly LLMModel[],
   customModels: string,
@@ -11,6 +17,7 @@ export function collectModelTable(
       name: string;
       displayName: string;
       provider?: LLMModel["provider"]; // Marked as optional
+      isDefault?: boolean;
     }
   > = {};
 
@@ -20,12 +27,6 @@ export function collectModelTable(
       ...m,
       displayName: m.name, // 'provider' is copied over if it exists
     };
-  });
-
-  const customProvider = (modelName: string) => ({
-    id: modelName,
-    providerName: "",
-    providerType: "custom",
   });
 
   // server custom models
@@ -52,6 +53,27 @@ export function collectModelTable(
         };
       }
     });
+
+  return modelTable;
+}
+
+export function collectModelTableWithDefaultModel(
+  models: readonly LLMModel[],
+  customModels: string,
+  defaultModel: string,
+) {
+  let modelTable = collectModelTable(models, customModels);
+  if (defaultModel && defaultModel !== "") {
+    delete modelTable[defaultModel];
+    modelTable[defaultModel] = {
+      name: defaultModel,
+      displayName: defaultModel,
+      available: true,
+      provider:
+        modelTable[defaultModel]?.provider ?? customProvider(defaultModel),
+      isDefault: true,
+    };
+  }
   return modelTable;
 }
 
@@ -65,5 +87,19 @@ export function collectModels(
   const modelTable = collectModelTable(models, customModels);
   const allModels = Object.values(modelTable);
 
+  return allModels;
+}
+
+export function collectModelsWithDefaultModel(
+  models: readonly LLMModel[],
+  customModels: string,
+  defaultModel: string,
+) {
+  const modelTable = collectModelTableWithDefaultModel(
+    models,
+    customModels,
+    defaultModel,
+  );
+  const allModels = Object.values(modelTable);
   return allModels;
 }


### PR DESCRIPTION
A new **optional env `DEFAULT_MODEL`** is supported now.

For example:

```bash
docker run --rm  -p 63000:3000 \
-e OPENAI_API_KEY=sk-jKxxxxxxxxxxxxxxxxxxxxxxxxx \
-e CODE=jalr4ever \
-e BASE_URL=https://api.proxychat.com.cn \
-e HIDE_USER_API_KEY=1 \
-e CUSTOM_MODELS=-all,+gpt-3.5-turbo-0613,+gpt-3.5-turbo-0301,+gpt-3.5-turbo-16k,+gpt-4-turbo,+gpt-4-0125-preview,+gemini-pro \
-e DEFAULT_MODEL=gpt-4-turbo \
-e GOOGLE_API_KEY=AIzaaaaaaaaaaaaaaaaaaaa \
-e GOOGLE_URL=https://mellifluous-aaaaaaaaaa.app \
jalr4ever/chatgpt-next-web:v2.11.3 
```
The feature version is already published in docker hub, you can just simply run `docker pull jalr4ever/chatgpt-next-web:v2.11.3` for usage preview.

