### PR TITLE
chore: No outline when element is in `:focus-visible` state

### DIFF
--- a/app/styles/globals.scss
+++ b/app/styles/globals.scss
@@ -86,6 +86,7 @@
     @include dark;
   }
 }
+
 html {
   height: var(--full-height);
 
@@ -109,6 +110,10 @@ body {
 
   @media only screen and (max-width: 600px) {
     background-color: var(--second);
+  }
+
+  *:focus-visible {
+    outline: none;
   }
 }
 


### PR DESCRIPTION
好像chrome前几个版本开始，部分页面元素在`:focus-visible`的时候会带上outline边框。

比如聊天界面内，点击空白区域，随后点击shift，则会触发。其余地方暂时不会，但是通过devtools手动添加`:focus-visible`后就会显现。

暂时在body中全局修改，如果有需要注意的地方还请指出来。

<img width="1588" alt="image" src="https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/assets/31413093/7b57d946-252d-467e-9a90-5fab8a57ea24">