### PR TITLE
remove max_tokens from the official version of gpt4-turbo

### DIFF
--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -129,7 +129,7 @@ export class ChatGPTApi implements LLMApi {
     };
 
     // add max_tokens to vision model
-    if (visionModel) {
+    if (visionModel && modelConfig.model.includes("preview")) {
       requestPayload["max_tokens"] = Math.max(modelConfig.max_tokens, 4000);
     }
 


### PR DESCRIPTION
The official version of gpt4 turbo no longer requires the "max_tokens" field