### PR TITLE
Summarize the content using the current conversation model

### DIFF
--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -12,6 +12,7 @@ import DeleteIcon from "../icons/delete.svg";
 import MaskIcon from "../icons/mask.svg";
 import PluginIcon from "../icons/plugin.svg";
 import DragIcon from "../icons/drag.svg";
+import ServerStack from "../icons/ServerStack.svg";
 
 import Locale from "../locales";
 
@@ -158,7 +159,7 @@ export function SideBar(props: { className?: string }) {
           NextChat
         </div>
         <div className={styles["sidebar-sub-title"]}>
-          Build your own AI assistant.
+          驾驭未来的最好方式就是创造未来
         </div>
         <div className={styles["sidebar-logo"] + " no-dark"}>
           <ChatGptIcon />
@@ -220,6 +221,11 @@ export function SideBar(props: { className?: string }) {
             <a href={REPO_URL} target="_blank" rel="noopener noreferrer">
               <IconButton icon={<GithubIcon />} shadow />
             </a>
+          </div>
+          <div className={styles["sidebar-action"]}>
+            <a href="https://stats.uptimerobot.com/TTbVUvRqXZ" target="_blank" rel="status">
+              <IconButton icon={<ServerStack />} shadow />
+             </a>
           </div>
         </div>
         <div>

--- a/app/constant.ts
+++ b/app/constant.ts
@@ -1,4 +1,4 @@
-export const OWNER = "Yidadaa";
+export const OWNER = "chengtx809";
 export const REPO = "ChatGPT-Next-Web";
 export const REPO_URL = `https://github.com/${OWNER}/${REPO}`;
 export const ISSUE_URL = `https://github.com/${OWNER}/${REPO}/issues`;

--- a/app/constant.ts
+++ b/app/constant.ts
@@ -119,8 +119,10 @@ Latex inline: \\(x^2\\)
 Latex block: $$e=mc^2$$
 `;
 
-export const SUMMARIZE_MODEL = "gpt-3.5-turbo";
-export const GEMINI_SUMMARIZE_MODEL = "gemini-pro";
+export const UsedModel= `{{model}}`;
+
+export const SUMMARIZE_MODEL = UsedModel;
+export const GEMINI_SUMMARIZE_MODEL = UsedModel;
 
 export const KnowledgeCutOffDate: Record<string, string> = {
   default: "2021-09",

--- a/app/icons/ServerStack.svg
+++ b/app/icons/ServerStack.svg
@@ -1,0 +1,3 @@
+<svg data-slot="icon" fill="none" stroke-width="1.5" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 14.25h13.5m-13.5 0a3 3 0 0 1-3-3m3 3a3 3 0 1 0 0 6h13.5a3 3 0 1 0 0-6m-16.5-3a3 3 0 0 1 3-3h13.5a3 3 0 0 1 3 3m-19.5 0a4.5 4.5 0 0 1 .9-2.7L5.737 5.1a3.375 3.375 0 0 1 2.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 0 1 .9 2.7m0 0a3 3 0 0 1-3 3m0 3h.008v.008h-.008v-.008Zm0-6h.008v.008h-.008v-.008Zm-3 6h.008v.008h-.008v-.008Zm0-6h.008v.008h-.008v-.008Z"></path>
+</svg>

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -442,23 +442,23 @@ export const useChatStore = createPersistStore(
           session.mask.modelConfig.model.startsWith("gpt-");
 
         var systemPrompts: ChatMessage[] = [];
-        systemPrompts = shouldInjectSystemPrompts
-          ? [
-              createMessage({
-                role: "system",
-                content: fillTemplateWith("", {
-                  ...modelConfig,
-                  template: DEFAULT_SYSTEM_TEMPLATE,
-                }),
-              }),
-            ]
-          : [];
-        if (shouldInjectSystemPrompts) {
-          console.log(
-            "[Global System Prompt] ",
-            systemPrompts.at(0)?.content ?? "empty",
-          );
-        }
+        // systemPrompts = shouldInjectSystemPrompts
+        //   ? [
+        //       createMessage({
+        //         role: "system",
+        //         content: fillTemplateWith("", {
+        //           ...modelConfig,
+        //           template: DEFAULT_SYSTEM_TEMPLATE,
+        //         }),
+        //       }),
+        //     ]
+        //   : [];
+        // if (shouldInjectSystemPrompts) {
+        //   console.log(
+        //     "[Global System Prompt] ",
+        //     systemPrompts.at(0)?.content ?? "empty",
+        //   );
+        // }
 
         // long term memory
         const shouldSendLongTermMemory =


### PR DESCRIPTION
Fix bug: #4587 
The bug comes from: app/constant.ts
```
export const SUMMARIZE_MODEL = "gpt-3.5-turbo";
export const GEMINI_SUMMARIZE_MODEL = "gemini-pro";
```
The problem of writing the summary model to death will result in the failure to summarize when using a non-GPT-3.5-turbo model
I changed it to:
```
export const UsedModel= `{{model}}`;

export const SUMMARIZE_MODEL = UsedModel;
export const GEMINI_SUMMARIZE_MODEL = UsedModel;
```
This automatically selects the model used for summarization