### PR TITLE
Fix max token limit parameter for larger models

### DIFF
--- a/app/components/model-config.tsx
+++ b/app/components/model-config.tsx
@@ -79,7 +79,7 @@ export function ModelConfigList(props: {
         <input
           type="number"
           min={1024}
-          max={512000}
+          max={1048576}
           value={props.modelConfig.max_tokens}
           onChange={(e) =>
             props.updateConfig(

--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -82,7 +82,7 @@ export const ModalConfigValidator = {
     return x as ModelType;
   },
   max_tokens(x: number) {
-    return limitNumber(x, 0, 512000, 1024);
+    return limitNumber(x, 0, 1048576, 1024);
   },
   presence_penalty(x: number) {
     return limitNumber(x, -2, 2, 0);


### PR DESCRIPTION
Original 512000 limit is not right for larger models such as gemini 1.5 pro, which need a limit up to 1049576.