### PR TITLE
Set gpt-4o as a vision model

### DIFF
--- a/app/utils.ts
+++ b/app/utils.ts
@@ -300,8 +300,11 @@ export function isVisionModel(model: string) {
   ];
   const isGpt4Turbo =
     model.includes("gpt-4-turbo") && !model.includes("preview");
+  
+  const isGpt4o =
+    model.includes("gpt-4o");
 
   return (
-    visionKeywords.some((keyword) => model.includes(keyword)) || isGpt4Turbo
+    visionKeywords.some((keyword) => model.includes(keyword)) || isGpt4Turbo || isGpt4o
   );
 }


### PR DESCRIPTION
OpenAI gpt-4o can support image input. so it should be considered as a vision model.

Openai document as below
https://platform.openai.com/docs/models/continuous-model-upgrades

![1715786788379](https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/assets/8396538/4e561094-148d-4697-9a75-c3eaae70b763)
