### PR TITLE
Revert "remove max_tokens from the official version of gpt4-turbo"

### DIFF
--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -129,7 +129,7 @@ export class ChatGPTApi implements LLMApi {
     };
 
     // add max_tokens to vision model
-    if (visionModel && modelConfig.model.includes("preview")) {
+    if (visionModel) {
       requestPayload["max_tokens"] = Math.max(modelConfig.max_tokens, 4000);
     }
 


### PR DESCRIPTION
This reverts commit dd4648ed9a803568b839e2510ca01cf7f1c6f740.

The `azure` - `gpt-4-turbo-2024-04-09` model still requires the `max_tokens` parameter,
so it doesn't work anymore since I updated to v2.12.3.

I think it is imprecise to simply determine whether the `preview` string is included,
and I hope to revert this commit until there is a more precise way to determine it.