### PR TITLE
修复自定义模型与预设模型名重复时,无法正确将自定义模型认定为openai渠道的bug

### DIFF
--- a/app/components/chat.module.scss
+++ b/app/components/chat.module.scss
@@ -87,6 +87,14 @@
       }
     }
 
+    &[data-expanded="true"] {
+      width: var(--full-width) !important; /* 始终保持展开状态 */
+      .text {
+        opacity: 1;
+        transform: translate(0);
+      }
+    }
+
     .text,
     .icon {
       display: flex;
@@ -458,7 +466,7 @@
     width: $calc-image-width;
     height: $calc-image-width;
   }
-  
+
   .chat-message-item-image {
     max-width: calc(100vw/3*2);
   }

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -341,6 +341,7 @@ function ChatAction(props: {
   text: string;
   icon: JSX.Element;
   onClick: () => void;
+  isExpanded?: boolean;
 }) {
   const iconRef = useRef<HTMLDivElement>(null);
   const textRef = useRef<HTMLDivElement>(null);
@@ -360,6 +361,9 @@ function ChatAction(props: {
     });
   }
 
+  useEffect(() => {
+    updateWidth();
+  }, [props.icon, props.text]);
   return (
     <div
       className={`${styles["chat-input-action"]} clickable`}
@@ -375,6 +379,7 @@ function ChatAction(props: {
           "--full-width": `${width.full}px`,
         } as React.CSSProperties
       }
+      data-expanded={props.isExpanded} // 使用 data 属性来控制样式
     >
       <div ref={iconRef} className={styles["icon"]}>
         {props.icon}
@@ -520,21 +525,21 @@ export function ChatActions(props: {
           icon={props.uploading ? <LoadingButtonIcon /> : <ImageIcon />}
         />
       )}
-      <ChatAction
-        onClick={nextTheme}
-        text={Locale.Chat.InputActions.Theme[theme]}
-        icon={
-          <>
-            {theme === Theme.Auto ? (
-              <AutoIcon />
-            ) : theme === Theme.Light ? (
-              <LightIcon />
-            ) : theme === Theme.Dark ? (
-              <DarkIcon />
-            ) : null}
-          </>
-        }
-      />
+      {/*<ChatAction*/}
+      {/*  onClick={nextTheme}*/}
+      {/*  text={Locale.Chat.InputActions.Theme[theme]}*/}
+      {/*  icon={*/}
+      {/*    <>*/}
+      {/*      {theme === Theme.Auto ? (*/}
+      {/*        <AutoIcon />*/}
+      {/*      ) : theme === Theme.Light ? (*/}
+      {/*        <LightIcon />*/}
+      {/*      ) : theme === Theme.Dark ? (*/}
+      {/*        <DarkIcon />*/}
+      {/*      ) : null}*/}
+      {/*    </>*/}
+      {/*  }*/}
+      {/*/>*/}
 
       <ChatAction
         onClick={props.showPromptHints}
@@ -551,25 +556,28 @@ export function ChatActions(props: {
       />
 
       <ChatAction
-        text={Locale.Chat.InputActions.Clear}
-        icon={<BreakIcon />}
-        onClick={() => {
-          chatStore.updateCurrentSession((session) => {
-            if (session.clearContextIndex === session.messages.length) {
-              session.clearContextIndex = undefined;
-            } else {
-              session.clearContextIndex = session.messages.length;
-              session.memoryPrompt = ""; // will clear memory
-            }
-          });
-        }}
-      />
-
-      <ChatAction
+        isExpanded={true}
         onClick={() => setShowModelSelector(true)}
         text={currentModel}
         icon={<RobotIcon />}
       />
+      <div style={{ marginLeft: "auto" }}>
+        <ChatAction
+          isExpanded={true}
+          text={Locale.Chat.InputActions.Clear}
+          icon={<BreakIcon />}
+          onClick={() => {
+            chatStore.updateCurrentSession((session) => {
+              if (session.clearContextIndex === session.messages.length) {
+                session.clearContextIndex = undefined;
+              } else {
+                session.clearContextIndex = session.messages.length;
+                session.memoryPrompt = ""; // will clear memory
+              }
+            });
+          }}
+        />
+      </div>
 
       {showModelSelector && (
         <Selector

--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -158,7 +158,7 @@ export function SideBar(props: { className?: string }) {
           NextChat
         </div>
         <div className={styles["sidebar-sub-title"]}>
-          Build your own AI assistant.
+          Build your own AI assistant. (by chenzhen)
         </div>
         <div className={styles["sidebar-logo"] + " no-dark"}>
           <ChatGptIcon />

--- a/app/constant.ts
+++ b/app/constant.ts
@@ -1,4 +1,4 @@
-export const OWNER = "Yidadaa";
+export const OWNER = "imaiya";
 export const REPO = "ChatGPT-Next-Web";
 export const REPO_URL = `https://github.com/${OWNER}/${REPO}`;
 export const ISSUE_URL = `https://github.com/${OWNER}/${REPO}/issues`;
@@ -149,7 +149,7 @@ const openaiModels = [
   "gpt-4o",
   "gpt-4o-2024-05-13",
   "gpt-4-vision-preview",
-  "gpt-4-turbo-2024-04-09"
+  "gpt-4-turbo-2024-04-09",
 ];
 
 const googleModels = [

--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -34,13 +34,13 @@ export const DEFAULT_CONFIG = {
   fontSize: 14,
   theme: Theme.Auto as Theme,
   tightBorder: !!config?.isApp,
-  sendPreviewBubble: true,
+  sendPreviewBubble: false,
   enableAutoGenerateTitle: true,
   sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
 
   disablePromptHint: false,
 
-  dontShowMaskSplashScreen: false, // dont show splash screen when create chat
+  dontShowMaskSplashScreen: true, // dont show splash screen when create chat
   hideBuiltinMasks: false, // dont add builtin masks
 
   customModels: "",

--- a/app/utils/model.ts
+++ b/app/utils/model.ts
@@ -2,7 +2,7 @@ import { LLMModel } from "../client/api";
 
 const customProvider = (modelName: string) => ({
   id: modelName,
-  providerName: "",
+  providerName: "*OpenAI",
   providerType: "custom",
 });
 
@@ -49,7 +49,7 @@ export function collectModelTable(
           name,
           displayName: displayName || name,
           available,
-          provider: modelTable[name]?.provider ?? customProvider(name), // Use optional chaining
+          provider: customProvider(name), // Use optional chaining
         };
       }
     });


### PR DESCRIPTION
- 有很多代理站在使用anthropic相关模型时,需要走OpenAi格式和渠道,所以需要使用自定义模型来添加,如果自定义模型名称重复,实际应该覆盖预置模型,而不是以预置模型为准.
- 自定义模型显示后缀为(*OpenAI),表示当前走的OpenAI格式


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated chat functionality to support expanded view with new styles.
	- Added a new `ChatAction` prop for expanded state.

- **Bug Fixes**
	- Corrected provider assignment for custom models to use "*OpenAI".

- **Style**
	- Enhanced chat component styles for better user experience.

- **Chores**
	- Updated owner information to "imaiya".
	- Adjusted default configuration flags for preview bubbles and splash screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->