### PR TITLE
Fix potential github action smells

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,18 +10,15 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Check out the repo
+      - name: Check out the repo
         uses: actions/checkout@v3
-      -
-        name: Log in to Docker Hub
+      - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       
-      - 
-        name: Extract metadata (tags, labels) for Docker
+      - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4
         with:
@@ -30,16 +27,13 @@ jobs:
             type=raw,value=latest
             type=ref,event=tag
       
-      - 
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
-      - 
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       
-      - 
-        name: Build and push Docker image
+      - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .

--- a/.github/workflows/issue-translator.yml
+++ b/.github/workflows/issue-translator.yml
@@ -8,8 +8,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'ChatGPTNextWeb/ChatGPT-Next-Web'
+    permissions: 
+      issues: write
     steps:
-      - uses: usthe/issues-translate-action@v2.7
+      - uses: usthe/issues-translate-action@b41f55ddc81d7d54bd542a4f289fe28ec081898e # v2.7
         with:
           IS_MODIFY_TITLE: false
           CUSTOM_BOT_NOTE: Bot detected the issue body's language is not English, translate it automatically.


### PR DESCRIPTION
Hey! 🙂
I've made the following changes to your workflow: 

- Avoid incorrectly indented workflows
  - Make sure that workflows are readable for other developers so that they can easily understand what the workflow is doing.
- Prevent running issue/PR actions on forks
  - Running workflows that modify issues on forks will fail because they do not have access to the issues on the original repository.
- Define permissions for workflows with external actions
  - Permissions should be used when running actions written by other developers because there may be security leaks exposed through these actions.
- Use commit hash instead of tags for action versions
  - When using a tag as version, the code related to the tag can be changed after the tag is created, whereas when using the commit hash this cannot. Therefore, for consistency and security a commit hash should be used.


(These changes are part of a research Study at TU Delft looking at GitHub Action Smells. [Find out more](https://ceddy4395.github.io/research/gha-smells.html))