### PR TITLE
fix: make env PROXY_URL avaliable in Docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ CMD if [ -n "$PROXY_URL" ]; then \
     echo "[ProxyList]" >> $conf; \
     echo "$protocol $host $port" >> $conf; \
     cat /etc/proxychains.conf; \
-    proxychains -f $conf "node server.js --host 0.0.0.0"; \
+    proxychains -f $conf node server.js --host 0.0.0.0; \
     else \
     node server.js; \
     fi


### PR DESCRIPTION
Fix the issue mentioned in https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/issues/4747.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated server start command in Dockerfile for improved compatibility with `proxychains`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->