### PR TITLE
Fix Google gemini  BASE_URL bug

### DIFF
--- a/app/client/platforms/google.ts
+++ b/app/client/platforms/google.ts
@@ -122,6 +122,8 @@ export class GeminiProApi implements LLMApi {
         baseUrl = isApp
           ? DEFAULT_API_HOST + "/api/proxy/google/" + Google.ChatPath(modelConfig.model)
           : this.path(Google.ChatPath(modelConfig.model));
+      } else if (isApp && !baseUrl.endsWith(":generateContent")) {
+        baseUrl += googleChatPath;
       }
 
       if (isApp) {


### PR DESCRIPTION
Fix Google gemini bug in client when configuring base_url
[@4783](https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/issues/3735)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the Google Chat integration to dynamically adjust the base URL based on specific conditions, improving connectivity and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->