### PR TITLE
Fix claude get headers

### DIFF
--- a/app/client/api.ts
+++ b/app/client/api.ts
@@ -184,7 +184,8 @@ export function getHeaders() {
       accessStore.enabledAccessControl() &&
       validString(accessStore.accessCode)
     ) {
-      headers[authHeader] = makeBearer(
+      // access_code must send with header named `Authorization`, will using in auth middleware.
+      headers['Authorization'] = makeBearer(
         ACCESS_CODE_PREFIX + accessStore.accessCode,
       );
     }

--- a/app/client/api.ts
+++ b/app/client/api.ts
@@ -162,14 +162,17 @@ export function getHeaders() {
   const modelConfig = useChatStore.getState().currentSession().mask.modelConfig;
   const isGoogle = modelConfig.model.startsWith("gemini");
   const isAzure = accessStore.provider === ServiceProvider.Azure;
-  const authHeader = isAzure ? "api-key" : "Authorization";
+  const isAnthropic = accessStore.provider === ServiceProvider.Anthropic;
+  const authHeader = isAzure ? "api-key" : isAnthropic ? 'x-api-key' : "Authorization";
   const apiKey = isGoogle
     ? accessStore.googleApiKey
     : isAzure
     ? accessStore.azureApiKey
+    : isAnthropic
+    ? accessStore.anthropicApiKey
     : accessStore.openaiApiKey;
   const clientConfig = getClientConfig();
-  const makeBearer = (s: string) => `${isAzure ? "" : "Bearer "}${s.trim()}`;
+  const makeBearer = (s: string) => `${isAzure || isAnthropic ? "" : "Bearer "}${s.trim()}`;
   const validString = (x: string) => x && x.length > 0;
 
   // when using google api in app, not set auth header

--- a/app/client/platforms/anthropic.ts
+++ b/app/client/platforms/anthropic.ts
@@ -1,5 +1,5 @@
 import { ACCESS_CODE_PREFIX, Anthropic, ApiPath } from "@/app/constant";
-import { ChatOptions, LLMApi, MultimodalContent } from "../api";
+import { ChatOptions, getHeaders, LLMApi, MultimodalContent,  } from "../api";
 import { useAccessStore, useAppConfig, useChatStore } from "@/app/store";
 import { getClientConfig } from "@/app/config/client";
 import { DEFAULT_API_HOST } from "@/app/constant";
@@ -190,9 +190,7 @@ export class ClaudeApi implements LLMApi {
       body: JSON.stringify(requestBody),
       signal: controller.signal,
       headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-        "x-api-key": accessStore.anthropicApiKey,
+        ...getHeaders(),  // get common headers
         "anthropic-version": accessStore.anthropicApiVersion,
         Authorization: getAuthKey(accessStore.anthropicApiKey),
       },

--- a/app/client/platforms/anthropic.ts
+++ b/app/client/platforms/anthropic.ts
@@ -192,7 +192,8 @@ export class ClaudeApi implements LLMApi {
       headers: {
         ...getHeaders(),  // get common headers
         "anthropic-version": accessStore.anthropicApiVersion,
-        Authorization: getAuthKey(accessStore.anthropicApiKey),
+        // do not send `anthropicApiKey` in browser!!!
+        // Authorization: getAuthKey(accessStore.anthropicApiKey),
       },
     };
 
@@ -386,28 +387,4 @@ function trimEnd(s: string, end = " ") {
   }
 
   return s;
-}
-
-function bearer(value: string) {
-  return `Bearer ${value.trim()}`;
-}
-
-function getAuthKey(apiKey = "") {
-  const accessStore = useAccessStore.getState();
-  const isApp = !!getClientConfig()?.isApp;
-  let authKey = "";
-
-  if (apiKey) {
-    // use user's api key first
-    authKey = bearer(apiKey);
-  } else if (
-    accessStore.enabledAccessControl() &&
-    !isApp &&
-    !!accessStore.accessCode
-  ) {
-    // or use access code
-    authKey = bearer(ACCESS_CODE_PREFIX + accessStore.accessCode);
-  }
-
-  return authKey;
 }


### PR DESCRIPTION
- [x] anthropic client using common getHeaders
- [x] do not send `anthropicApiKey` in browser!!!
- [x] always using `Authorization` header send access code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced header configuration to support `Azure`, `Google`, and `Anthropic` providers.

- **Bug Fixes**
  - Improved API key handling for different cloud providers.

- **Refactor**
  - Streamlined header assignment logic for better maintainability.
  

<!-- end of auto-generated comment: release notes by coderabbit.ai -->