### PR TITLE
feat: 修改openai的请求url，之前env填写base_url=cloudflare ai

### DIFF
--- a/app/api/common.ts
+++ b/app/api/common.ts
@@ -24,11 +24,10 @@ export async function requestOpenai(req: NextRequest) {
     authValue = req.headers.get("Authorization") ?? "";
     authHeaderName = "Authorization";
   }
-
-  let path = `${req.nextUrl.pathname}${req.nextUrl.search}`.replaceAll(
-    "/api/openai/",
-    "",
-  );
+  const requestUrl = `${req.nextUrl.pathname}${req.nextUrl.search}`;
+  let path = requestUrl.startsWith("https://gateway.ai.cloudflare.com")
+    ? requestUrl.replaceAll("/api/openai/v1/", "")
+    : requestUrl.replaceAll("/api/openai/", "");
 
   let baseUrl =
     serverConfig.azureUrl || serverConfig.baseUrl || OPENAI_BASE_URL;


### PR DESCRIPTION
getway的时候会报错，
{
  "error": {
    "type": "invalid_request_error",
    "code": "unknown_url",
    "message": "Unknown request URL: POST /v1/v1/chat/completions?path=v1&path=chat&path=completions. Please check the URL for typos, or see the docs at https://platform.openai.com/docs/api-reference/.",
    "param": null
  }
}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved URL handling for OpenAI requests to support different URL patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->