### PR TITLE
hotfix: doubao display name

### DIFF
--- a/app/utils/model.ts
+++ b/app/utils/model.ts
@@ -61,7 +61,7 @@ export function collectModelTable(
             modelTable[fullName]["available"] = available;
             // swap name and displayName for bytedance
             if (providerName === "bytedance") {
-              [name, displayName] = [displayName, name];
+              [name, displayName] = [displayName, modelName];
               modelTable[fullName]["name"] = name;
             }
             if (displayName) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the model information display logic for ByteDance providers to use `modelName` instead of `name`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->