### PR TITLE
fix no max_tokens in payload when the vision model name does not cont…

### DIFF
--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -190,7 +190,7 @@ export class ChatGPTApi implements LLMApi {
       };
 
       // add max_tokens to vision model
-      if (visionModel && modelConfig.model.includes("preview")) {
+      if (visionModel) {
         requestPayload["max_tokens"] = Math.max(modelConfig.max_tokens, 4000);
       }
     }


### PR DESCRIPTION
…ain 'vision'.

#### 💻 变更类型 | Change Type

- [ ] feat    <!-- 引入新功能 | Introduce new features -->
- [x] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [ ] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don’t modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->

#### 🔀 变更说明 | Description of Change

Fix  no 'max_tokens' in the payload when the vision model name does not contain 'vision'


#### 📝 补充信息 | Additional Information

`&& modelConfig.model.includes("preview")`  会导致常规 vision model 走不进 if 代码块，从而无法设置max_tokens

本地出现的bug是上传图片后，openai回复断流。 删除 `&&` 后正常


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified the logic for assigning the `max_tokens` parameter in the vision model requests, enhancing compatibility across various model configurations.

- **Bug Fixes**
	- Improved request handling for vision models, ensuring that `max_tokens` is applied more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->