### PR TITLE
fix(#5378): default plugin ids to empty array

### DIFF
--- a/app/client/platforms/anthropic.ts
+++ b/app/client/platforms/anthropic.ts
@@ -203,7 +203,7 @@ export class ClaudeApi implements LLMApi {
       const [tools, funcs] = usePluginStore
         .getState()
         .getAsTools(
-          useChatStore.getState().currentSession().mask?.plugin as string[],
+          useChatStore.getState().currentSession().mask?.plugin || [],
         );
       return stream(
         path,

--- a/app/client/platforms/moonshot.ts
+++ b/app/client/platforms/moonshot.ts
@@ -125,7 +125,7 @@ export class MoonshotApi implements LLMApi {
         const [tools, funcs] = usePluginStore
           .getState()
           .getAsTools(
-            useChatStore.getState().currentSession().mask?.plugin as string[],
+            useChatStore.getState().currentSession().mask?.plugin || [],
           );
         return stream(
           chatPath,

--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -244,7 +244,7 @@ export class ChatGPTApi implements LLMApi {
         const [tools, funcs] = usePluginStore
           .getState()
           .getAsTools(
-            useChatStore.getState().currentSession().mask?.plugin as string[],
+            useChatStore.getState().currentSession().mask?.plugin || [],
           );
         // console.log("getAsTools", tools, funcs);
         stream(


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] feat    <!-- 引入新功能 | Introduce new features -->
- [x] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [ ] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don’t modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->

#### 🔀 变更说明 | Description of Change

Fixes #5378.

#### 📝 补充信息 | Additional Information

https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/issues/5378#issuecomment-2335187503


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the API by ensuring that the `getAsTools` method receives a valid array, preventing potential runtime errors when the `plugin` property is undefined or null.

- **Refactor**
	- Enhanced the robustness of the `getAsTools` method calls across multiple API classes by implementing a fallback mechanism for the `plugin` property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->