### PR TITLE
feat: menual regen title

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -43,6 +43,7 @@ import QualityIcon from "../icons/hd.svg";
 import StyleIcon from "../icons/palette.svg";
 import PluginIcon from "../icons/plugin.svg";
 import ShortcutkeyIcon from "../icons/shortcutkey.svg";
+import ReloadIcon from "../icons/reload.svg";
 
 import {
   ChatMessage,
@@ -1541,6 +1542,17 @@ function _Chat() {
           </div>
         </div>
         <div className="window-actions">
+          <div className="window-action-button">
+            <IconButton
+              icon={<ReloadIcon />}
+              bordered
+              title={Locale.Chat.Actions.RefreshTitle}
+              onClick={() => {
+                showToast(Locale.Chat.Actions.RefreshToast);
+                chatStore.summarizeSession(true);
+              }}
+            />
+          </div>
           {!isMobileScreen && (
             <div className="window-action-button">
               <IconButton

--- a/app/locales/ar.ts
+++ b/app/locales/ar.ts
@@ -43,6 +43,8 @@ const ar: PartialLocaleType = {
       PinToastAction: "عرض",
       Delete: "حذف",
       Edit: "تحرير",
+      RefreshTitle: "تحديث العنوان",
+      RefreshToast: "تم إرسال طلب تحديث العنوان",
     },
     Commands: {
       new: "دردشة جديدة",

--- a/app/locales/bn.ts
+++ b/app/locales/bn.ts
@@ -43,6 +43,8 @@ const bn: PartialLocaleType = {
       PinToastAction: "দেখুন",
       Delete: "মুছে ফেলুন",
       Edit: "সম্পাদনা করুন",
+      RefreshTitle: "শিরোনাম রিফ্রেশ করুন",
+      RefreshToast: "শিরোনাম রিফ্রেশ অনুরোধ পাঠানো হয়েছে",
     },
     Commands: {
       new: "নতুন চ্যাট",

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -44,6 +44,8 @@ const cn = {
       Delete: "删除",
       Edit: "编辑",
       FullScreen: "全屏",
+      RefreshTitle: "刷新标题",
+      RefreshToast: "已发送刷新标题请求",
     },
     Commands: {
       new: "新建聊天",

--- a/app/locales/cs.ts
+++ b/app/locales/cs.ts
@@ -43,6 +43,8 @@ const cs: PartialLocaleType = {
       PinToastAction: "Zobrazit",
       Delete: "Smazat",
       Edit: "Upravit",
+      RefreshTitle: "Obnovit název",
+      RefreshToast: "Požadavek na obnovení názvu byl odeslán",
     },
     Commands: {
       new: "Nová konverzace",

--- a/app/locales/de.ts
+++ b/app/locales/de.ts
@@ -43,6 +43,8 @@ const de: PartialLocaleType = {
       PinToastAction: "Ansehen",
       Delete: "Löschen",
       Edit: "Bearbeiten",
+      RefreshTitle: "Titel aktualisieren",
+      RefreshToast: "Anfrage zur Titelaktualisierung gesendet",
     },
     Commands: {
       new: "Neues Gespräch",

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -45,6 +45,8 @@ const en: LocaleType = {
       Delete: "Delete",
       Edit: "Edit",
       FullScreen: "FullScreen",
+      RefreshTitle: "Refresh Title",
+      RefreshToast: "Title refresh request sent",
     },
     Commands: {
       new: "Start a new chat",

--- a/app/locales/es.ts
+++ b/app/locales/es.ts
@@ -44,6 +44,8 @@ const es: PartialLocaleType = {
       PinToastAction: "Ver",
       Delete: "Eliminar",
       Edit: "Editar",
+      RefreshTitle: "Actualizar título",
+      RefreshToast: "Se ha enviado la solicitud de actualización del título",
     },
     Commands: {
       new: "Nueva conversación",

--- a/app/locales/fr.ts
+++ b/app/locales/fr.ts
@@ -43,6 +43,8 @@ const fr: PartialLocaleType = {
       PinToastAction: "Voir",
       Delete: "Supprimer",
       Edit: "Modifier",
+      RefreshTitle: "Actualiser le titre",
+      RefreshToast: "Demande d'actualisation du titre envoyée",
     },
     Commands: {
       new: "Nouvelle discussion",

--- a/app/locales/id.ts
+++ b/app/locales/id.ts
@@ -43,6 +43,8 @@ const id: PartialLocaleType = {
       PinToastAction: "Lihat",
       Delete: "Hapus",
       Edit: "Edit",
+      RefreshTitle: "Segarkan Judul",
+      RefreshToast: "Permintaan penyegaran judul telah dikirim",
     },
     Commands: {
       new: "Obrolan Baru",

--- a/app/locales/it.ts
+++ b/app/locales/it.ts
@@ -43,6 +43,8 @@ const it: PartialLocaleType = {
       PinToastAction: "Visualizza",
       Delete: "Elimina",
       Edit: "Modifica",
+      RefreshTitle: "Aggiorna titolo",
+      RefreshToast: "Richiesta di aggiornamento del titolo inviata",
     },
     Commands: {
       new: "Nuova chat",

--- a/app/locales/jp.ts
+++ b/app/locales/jp.ts
@@ -43,6 +43,8 @@ const jp: PartialLocaleType = {
       PinToastAction: "見る",
       Delete: "削除",
       Edit: "編集",
+      RefreshTitle: "タイトルを更新",
+      RefreshToast: "タイトル更新リクエストが送信されました",
     },
     Commands: {
       new: "新しいチャット",

--- a/app/locales/ko.ts
+++ b/app/locales/ko.ts
@@ -43,6 +43,8 @@ const ko: PartialLocaleType = {
       PinToastAction: "보기",
       Delete: "삭제",
       Edit: "편집",
+      RefreshTitle: "제목 새로고침",
+      RefreshToast: "제목 새로고침 요청이 전송되었습니다",
     },
     Commands: {
       new: "새 채팅",

--- a/app/locales/no.ts
+++ b/app/locales/no.ts
@@ -44,6 +44,8 @@ const no: PartialLocaleType = {
       PinToastAction: "Se",
       Delete: "Slett",
       Edit: "Rediger",
+      RefreshTitle: "Oppdater tittel",
+      RefreshToast: "Forespørsel om titteloppdatering sendt",
     },
     Commands: {
       new: "Ny samtale",

--- a/app/locales/pt.ts
+++ b/app/locales/pt.ts
@@ -43,6 +43,8 @@ const pt: PartialLocaleType = {
       PinToastAction: "Visualizar",
       Delete: "Deletar",
       Edit: "Editar",
+      RefreshTitle: "Atualizar Título",
+      RefreshToast: "Solicitação de atualização de título enviada",
     },
     Commands: {
       new: "Iniciar um novo chat",

--- a/app/locales/ru.ts
+++ b/app/locales/ru.ts
@@ -43,6 +43,8 @@ const ru: PartialLocaleType = {
       PinToastAction: "Просмотреть",
       Delete: "Удалить",
       Edit: "Редактировать",
+      RefreshTitle: "Обновить заголовок",
+      RefreshToast: "Запрос на обновление заголовка отправлен",
     },
     Commands: {
       new: "Новый чат",

--- a/app/locales/sk.ts
+++ b/app/locales/sk.ts
@@ -45,6 +45,8 @@ const sk: PartialLocaleType = {
       PinToastAction: "Zobraziť",
       Delete: "Vymazať",
       Edit: "Upraviť",
+      RefreshTitle: "Obnoviť názov",
+      RefreshToast: "Požiadavka na obnovenie názvu bola odoslaná",
     },
     Commands: {
       new: "Začať nový chat",

--- a/app/locales/tr.ts
+++ b/app/locales/tr.ts
@@ -43,6 +43,8 @@ const tr: PartialLocaleType = {
       PinToastAction: "Görünüm",
       Delete: "Sil",
       Edit: "Düzenle",
+      RefreshTitle: "Başlığı Yenile",
+      RefreshToast: "Başlık yenileme isteği gönderildi",
     },
     Commands: {
       new: "Yeni sohbet",

--- a/app/locales/tw.ts
+++ b/app/locales/tw.ts
@@ -43,6 +43,8 @@ const tw = {
       PinToastAction: "檢視",
       Delete: "刪除",
       Edit: "編輯",
+      RefreshTitle: "刷新標題",
+      RefreshToast: "已發送刷新標題請求",
     },
     Commands: {
       new: "新建聊天",

--- a/app/locales/vi.ts
+++ b/app/locales/vi.ts
@@ -43,6 +43,8 @@ const vi: PartialLocaleType = {
       PinToastAction: "Xem",
       Delete: "Xóa",
       Edit: "Chỉnh sửa",
+      RefreshTitle: "Làm mới tiêu đề",
+      RefreshToast: "Đã gửi yêu cầu làm mới tiêu đề",
     },
     Commands: {
       new: "Tạo cuộc trò chuyện mới",

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -572,7 +572,7 @@ export const useChatStore = createPersistStore(
         });
       },
 
-      summarizeSession() {
+      summarizeSession(refreshTitle: boolean = false) {
         const config = useAppConfig.getState();
         const session = get().currentSession();
         const modelConfig = session.mask.modelConfig;
@@ -590,16 +590,22 @@ export const useChatStore = createPersistStore(
         // should summarize topic after chating more than 50 words
         const SUMMARIZE_MIN_LEN = 50;
         if (
-          config.enableAutoGenerateTitle &&
-          session.topic === DEFAULT_TOPIC &&
-          countMessages(messages) >= SUMMARIZE_MIN_LEN
+          (config.enableAutoGenerateTitle &&
+            session.topic === DEFAULT_TOPIC &&
+            countMessages(messages) >= SUMMARIZE_MIN_LEN) ||
+          refreshTitle
         ) {
-          const topicMessages = messages.concat(
-            createMessage({
-              role: "user",
-              content: Locale.Store.Prompt.Topic,
-            }),
-          );
+          const topicMessages = messages
+            .slice(
+              messages.length - modelConfig.historyMessageCount,
+              messages.length,
+            )
+            .concat(
+              createMessage({
+                role: "user",
+                content: Locale.Store.Prompt.Topic,
+              }),
+            );
           api.llm.chat({
             messages: topicMessages,
             config: {

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -595,9 +595,13 @@ export const useChatStore = createPersistStore(
             countMessages(messages) >= SUMMARIZE_MIN_LEN) ||
           refreshTitle
         ) {
+          const startIndex = Math.max(
+            0,
+            messages.length - modelConfig.historyMessageCount,
+          );
           const topicMessages = messages
             .slice(
-              messages.length - modelConfig.historyMessageCount,
+              startIndex < messages.length ? startIndex : messages.length - 1,
               messages.length,
             )
             .concat(


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [X] feat    <!-- 引入新功能 | Introduce new features -->
- [ ] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [ ] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don’t modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->

#### 🔀 变更说明 | Description of Change

添加按钮使得标题可以手动更新

#### 📝 补充信息 | Additional Information

split from #5426 

标题刷新按钮在手机上的布局可能不好看（不对称），但我一时间也想不到更好的布局方案。

现在手动刷新标题发送的历史长度基于用户在模型设置里设置的发送历史的长度，最短为最近的一条历史消息。
