### PR TITLE
fix: config hydration and default model forced to set gpt-3.5-turbo

### DIFF
--- a/app/store/access.ts
+++ b/app/store/access.ts
@@ -204,8 +204,8 @@ export const useAccessStore = createPersistStore(
         .then((res) => {
           // Set default model from env request
           let defaultModel = res.defaultModel ?? "";
-          DEFAULT_CONFIG.modelConfig.model =
-            defaultModel !== "" ? defaultModel : "gpt-3.5-turbo";
+          if (defaultModel !== "")
+            DEFAULT_CONFIG.modelConfig.model = defaultModel;
           return res;
         })
         .then((res: DangerConfig) => {

--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -143,6 +143,21 @@ export const useAppConfig = createPersistStore(
   {
     name: StoreKey.Config,
     version: 4,
+
+    merge(persistedState, currentState) {
+      const state = persistedState as ChatConfig | undefined;
+      if (!state) return { ...currentState };
+      const models = currentState.models.slice();
+      state.models.forEach((pModel) => {
+        const idx = models.findIndex(
+          (v) => v.name === pModel.name && v.provider === pModel.provider,
+        );
+        if (idx !== -1) models[idx] = pModel;
+        else models.push(pModel);
+      });
+      return { ...currentState, ...state, models: models };
+    },
+
     migrate(persistedState, version) {
       const state = persistedState as ChatConfig;
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] feat    <!-- 引入新功能 | Introduce new features -->
- [X] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [ ] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don’t modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->

#### 🔀 变更说明 | Description of Change

修复了持久模型不随源码更新而更新的问题

修复了当服务器未设置默认模型时默认模型不跟随 `DEFAULT_CONFIG` 而被强制设置为 `gpt-3.5-turbo` 的问题

#### 📝 补充信息 | Additional Information

#5433 应当是历史遗留问题：zustand 在水和时，默认执行的是 `{...currentState, ...persistedState}`，这样做很不幸 `models` 会被 `persistedState` 覆盖；同时 `mergeModels` 方法在 `home` 组件挂载时，会被执行一次，可见

https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/blob/027e5adf67ddf36a4e11c9bca126c8b255abfdad/app/components/home.tsx#L209-L221

可能是由于竞争的关系，很不幸 `mergeModels` 的努力会被 zustand 水合时给覆盖掉，**但** 在开发时，React 严格模式会挂载组件 **两次**，而此刻 `mergeModels` 竞争过了水合，所以在开发模式下未重现此问题；而平常很多人的使用环境都是在 server 端 customize 模型，所以很难发现这种问题。

我认为所有找不到 o1 模型的人，理应也找不到 `chatgpt-4o-latest` 等随着时间更新的模型。个人愚见，欢迎讨论。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function to merge persisted application states, improving configuration management.
- **Improvements**
	- Enhanced logic for setting default model configurations, ensuring clarity and better handling of model defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->