### PR TITLE
fix: Avoid fetching prompts.json serverside

### DIFF
--- a/app/store/prompt.ts
+++ b/app/store/prompt.ts
@@ -1,7 +1,7 @@
 import Fuse from "fuse.js";
-import { getLang } from "../locales";
-import { StoreKey } from "../constant";
 import { nanoid } from "nanoid";
+import { StoreKey } from "../constant";
+import { getLang } from "../locales";
 import { createPersistStore } from "../utils/store";
 
 export interface Prompt {
@@ -147,6 +147,11 @@ export const usePromptStore = createPersistStore(
     },
 
     onRehydrateStorage(state) {
+      // Skip store rehydration on server side
+      if (typeof window === "undefined") {
+        return;
+      }
+      
       const PROMPT_URL = "./prompts.json";
 
       type PromptList = Array<[string, string]>;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] feat    <!-- 引入新功能 | Introduce new features -->
- [x] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [ ] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don’t modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->

#### 🔀 变更说明 | Description of Change

Running fetch with a relative path in not possible server side. To avoid the fetching server side, checking if `window` is undefined and doing an early return if so resolves the issue.

<!-- 
感谢您的 Pull Request ，请提供此 Pull Request 的变更说明
Thank you for your Pull Request. Please provide a description above.
-->

#### 📝 补充信息 | Additional Information

This fix should resolve:

- [https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/issues/5412](https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/issues/5412)
- [https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/issues/5423](https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/issues/5423)

<!-- 
请添加与此 Pull Request 相关的补充信息
Add any other context about the Pull Request here.
-->
