### PR TITLE
fix: On mobile devices, pressing Enter by default does not send the message, but performs a normal line break

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -1098,7 +1098,7 @@ function _Chat() {
       e.preventDefault();
       return;
     }
-    if (shouldSubmit(e) && promptHints.length === 0) {
+    if (!isMobileScreen && shouldSubmit(e) && promptHints.length === 0) {
       doSubmit(userInput);
       e.preventDefault();
     }


### PR DESCRIPTION
…message, but performs a normal line break

#### 💻 变更类型 | Change Type

- [x] fix   On mobile devices, pressing Enter by default does not send the message, but performs a normal line break

#### 🔀 变更说明 | Description of Change

Just like ChatGPT, use Enter to send messages on desktop? No problem, I can use Shift+Enter for line breaks. Do the same on mobile? That's strange. This is ChatGPT's different behavior on desktop and mobile.

https://github.com/user-attachments/assets/96f19465-c834-4e56-84b8-7bfb8237a8aa

#### 📝 补充信息 | Additional Information

<!-- 
请添加与此 Pull Request 相关的补充信息
Add any other context about the Pull Request here.
-->
