### PR TITLE
feat: Implement Vertex AI support for Anthropic and Google models

### DIFF
--- a/app/client/api.ts
+++ b/app/client/api.ts
@@ -317,7 +317,14 @@ export function getHeaders(ignoreHeaders: boolean = false) {
 
   if (bearerToken) {
     headers[authHeader] = bearerToken;
-  } else if (isEnabledAccessControl && validString(accessStore.accessCode)) {
+  }
+  // ensure access code is being sent when access control is enabled,
+  // this will fix an issue where the access code is not being sent when provider is google, azure or anthropic
+  if (
+    isEnabledAccessControl &&
+    validString(accessStore.accessCode) &&
+    authHeader !== "Authorization"
+  ) {
     headers["Authorization"] = getBearerToken(
       ACCESS_CODE_PREFIX + accessStore.accessCode,
     );

--- a/app/config/server.ts
+++ b/app/config/server.ts
@@ -44,6 +44,10 @@ declare global {
       ANTHROPIC_API_KEY?: string;
       ANTHROPIC_API_VERSION?: string;
 
+      // google cloud vertex ai only
+      VERTEX_AI_URL?: string; // https://{loc}-aiaiplatfor.googleapis.com/v1/{project}/locations/{loc}/models/{model}/versions/{version}:predict
+      GOOGLE_CLOUD_JSON_KEY?: string; // service account json key content
+
       // baidu only
       BAIDU_URL?: string;
       BAIDU_API_KEY?: string;
@@ -148,6 +152,7 @@ export const getServerSideConfig = () => {
   const isGoogle = !!process.env.GOOGLE_API_KEY;
   const isAnthropic = !!process.env.ANTHROPIC_API_KEY;
   const isTencent = !!process.env.TENCENT_API_KEY;
+  const isVertexAI = !!process.env.VERTEX_AI_URL;
 
   const isBaidu = !!process.env.BAIDU_API_KEY;
   const isBytedance = !!process.env.BYTEDANCE_API_KEY;
@@ -190,6 +195,10 @@ export const getServerSideConfig = () => {
     anthropicApiKey: getApiKey(process.env.ANTHROPIC_API_KEY),
     anthropicApiVersion: process.env.ANTHROPIC_API_VERSION,
     anthropicUrl: process.env.ANTHROPIC_URL,
+
+    isVertexAI,
+    vertexAIUrl: process.env.VERTEX_AI_URL,
+    googleCloudJsonKey: process.env.GOOGLE_CLOUD_JSON_KEY,
 
     isBaidu,
     baiduUrl: process.env.BAIDU_URL,

--- a/app/utils/chat.ts
+++ b/app/utils/chat.ts
@@ -3,7 +3,7 @@ import {
   UPLOAD_URL,
   REQUEST_TIMEOUT_MS,
 } from "@/app/constant";
-import { RequestMessage } from "@/app/client/api";
+import { ChatOptions, RequestMessage } from "@/app/client/api";
 import Locale from "@/app/locales";
 import {
   EventStreamContentType,
@@ -167,7 +167,7 @@ export function stream(
     toolCallMessage: any,
     toolCallResult: any[],
   ) => void,
-  options: any,
+  options: ChatOptions,
 ) {
   let responseText = "";
   let remainText = "";

--- a/app/utils/gtoken.ts
+++ b/app/utils/gtoken.ts
@@ -1,0 +1,285 @@
+/**
+ * npm:gtoken patched version for nextjs edge runtime, by ryanhex53
+ */
+// import { default as axios } from "axios";
+import { SignJWT, importPKCS8 } from "jose";
+
+const GOOGLE_TOKEN_URL = "https://www.googleapis.com/oauth2/v4/token";
+const GOOGLE_REVOKE_TOKEN_URL =
+  "https://accounts.google.com/o/oauth2/revoke?token=";
+
+export type GetTokenCallback = (err: Error | null, token?: TokenData) => void;
+
+export interface Credentials {
+  privateKey: string;
+  clientEmail?: string;
+}
+
+export interface TokenData {
+  refresh_token?: string;
+  expires_in?: number;
+  access_token?: string;
+  token_type?: string;
+  id_token?: string;
+}
+
+export interface TokenOptions {
+  key: string;
+  email?: string;
+  iss?: string;
+  sub?: string;
+  scope?: string | string[];
+  additionalClaims?: Record<string | number | symbol, never>;
+  // Eagerly refresh unexpired tokens when they are within this many
+  // milliseconds from expiring".
+  // Defaults to 5 minutes (300,000 milliseconds).
+  eagerRefreshThresholdMillis?: number;
+}
+
+export interface GetTokenOptions {
+  forceRefresh?: boolean;
+}
+
+class ErrorWithCode extends Error {
+  constructor(
+    message: string,
+    public code: string,
+  ) {
+    super(message);
+  }
+}
+
+export class GoogleToken {
+  get accessToken() {
+    return this.rawToken ? this.rawToken.access_token : undefined;
+  }
+  get idToken() {
+    return this.rawToken ? this.rawToken.id_token : undefined;
+  }
+  get tokenType() {
+    return this.rawToken ? this.rawToken.token_type : undefined;
+  }
+  get refreshToken() {
+    return this.rawToken ? this.rawToken.refresh_token : undefined;
+  }
+  expiresAt?: number;
+  key: string = "";
+  iss?: string;
+  sub?: string;
+  scope?: string;
+  rawToken?: TokenData;
+  tokenExpires?: number;
+  email?: string;
+  additionalClaims?: Record<string | number | symbol, never>;
+  eagerRefreshThresholdMillis: number = 0;
+
+  #inFlightRequest?: undefined | Promise<TokenData | undefined>;
+
+  /**
+   * Create a GoogleToken.
+   *
+   * @param options  Configuration object.
+   */
+  constructor(options?: TokenOptions) {
+    this.#configure(options);
+  }
+
+  /**
+   * Returns whether the token has expired.
+   *
+   * @return true if the token has expired, false otherwise.
+   */
+  hasExpired() {
+    const now = new Date().getTime();
+    if (this.rawToken && this.expiresAt) {
+      return now >= this.expiresAt;
+    } else {
+      return true;
+    }
+  }
+
+  /**
+   * Returns whether the token will expire within eagerRefreshThresholdMillis
+   *
+   * @return true if the token will be expired within eagerRefreshThresholdMillis, false otherwise.
+   */
+  isTokenExpiring() {
+    const now = new Date().getTime();
+    const eagerRefreshThresholdMillis = this.eagerRefreshThresholdMillis ?? 0;
+    if (this.rawToken && this.expiresAt) {
+      return this.expiresAt <= now + eagerRefreshThresholdMillis;
+    } else {
+      return true;
+    }
+  }
+
+  /**
+   * Returns a cached token or retrieves a new one from Google.
+   *
+   * @param callback The callback function.
+   */
+  getToken(opts?: GetTokenOptions): Promise<TokenData | undefined>;
+  getToken(callback: GetTokenCallback, opts?: GetTokenOptions): void;
+  getToken(
+    callback?: GetTokenCallback | GetTokenOptions,
+    opts = {} as GetTokenOptions,
+  ): void | Promise<TokenData | undefined> {
+    if (typeof callback === "object") {
+      opts = callback as GetTokenOptions;
+      callback = undefined;
+    }
+    opts = Object.assign(
+      {
+        forceRefresh: false,
+      },
+      opts,
+    );
+
+    if (callback) {
+      const cb = callback as GetTokenCallback;
+      this.#getTokenAsync(opts).then((t) => cb(null, t), callback);
+      return;
+    }
+
+    return this.#getTokenAsync(opts);
+  }
+
+  async #getTokenAsync(opts: GetTokenOptions): Promise<TokenData | undefined> {
+    if (this.#inFlightRequest && !opts.forceRefresh) {
+      return this.#inFlightRequest;
+    }
+
+    try {
+      return await (this.#inFlightRequest = this.#getTokenAsyncInner(opts));
+    } finally {
+      this.#inFlightRequest = undefined;
+    }
+  }
+
+  async #getTokenAsyncInner(
+    opts: GetTokenOptions,
+  ): Promise<TokenData | undefined> {
+    if (this.isTokenExpiring() === false && opts.forceRefresh === false) {
+      return Promise.resolve(this.rawToken!);
+    }
+    if (!this.key) {
+      throw new Error("No key or keyFile set.");
+    }
+    if (!this.iss) {
+      throw new ErrorWithCode("email is required.", "MISSING_CREDENTIALS");
+    }
+    const token = await this.#requestToken();
+    return token;
+  }
+
+  /**
+   * Revoke the token if one is set.
+   *
+   * @param callback The callback function.
+   */
+  revokeToken(): Promise<void>;
+  revokeToken(callback: (err?: Error) => void): void;
+  revokeToken(callback?: (err?: Error) => void): void | Promise<void> {
+    if (callback) {
+      this.#revokeTokenAsync().then(() => callback(), callback);
+      return;
+    }
+    return this.#revokeTokenAsync();
+  }
+
+  async #revokeTokenAsync() {
+    if (!this.accessToken) {
+      throw new Error("No token to revoke.");
+    }
+    const url = GOOGLE_REVOKE_TOKEN_URL + this.accessToken;
+    // await axios.get(url, { timeout: 10000 });
+    // uncomment below if prefer using fetch, but fetch will not follow HTTPS_PROXY
+    await fetch(url, { method: "GET" });
+
+    this.#configure({
+      email: this.iss,
+      sub: this.sub,
+      key: this.key,
+      scope: this.scope,
+      additionalClaims: this.additionalClaims,
+    });
+  }
+
+  /**
+   * Configure the GoogleToken for re-use.
+   * @param  {object} options Configuration object.
+   */
+  #configure(options: TokenOptions = { key: "" }) {
+    this.key = options.key;
+    this.rawToken = undefined;
+    this.iss = options.email || options.iss;
+    this.sub = options.sub;
+    this.additionalClaims = options.additionalClaims;
+    if (typeof options.scope === "object") {
+      this.scope = options.scope.join(" ");
+    } else {
+      this.scope = options.scope;
+    }
+    this.eagerRefreshThresholdMillis =
+      options.eagerRefreshThresholdMillis || 5 * 60 * 1000;
+  }
+
+  /**
+   * Request the token from Google.
+   */
+  async #requestToken(): Promise<TokenData | undefined> {
+    const iat = Math.floor(new Date().getTime() / 1000);
+    const additionalClaims = this.additionalClaims || {};
+    const payload = Object.assign(
+      {
+        iss: this.iss,
+        scope: this.scope,
+        aud: GOOGLE_TOKEN_URL,
+        exp: iat + 3600,
+        iat,
+        sub: this.sub,
+      },
+      additionalClaims,
+    );
+    const privateKey = await importPKCS8(this.key, "RS256");
+    const signedJWT = await new SignJWT(payload)
+      .setProtectedHeader({ alg: "RS256" })
+      .sign(privateKey);
+    const body = new URLSearchParams();
+    body.append("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer");
+    body.append("assertion", signedJWT);
+    try {
+      // const res = await axios.post<TokenData>(GOOGLE_TOKEN_URL, body, {
+      //   headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      //   timeout: 15000,
+      //   validateStatus: (status) => {
+      //     return status >= 200 && status < 300;
+      //   },
+      // });
+      // this.rawToken = res.data;
+
+      // uncomment below if prefer using fetch, but fetch will not follow HTTPS_PROXY
+      const res = await fetch(GOOGLE_TOKEN_URL, {
+        method: "POST",
+        body,
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      });
+      this.rawToken = (await res.json()) as TokenData;
+
+      this.expiresAt =
+        this.rawToken.expires_in === null ||
+        this.rawToken.expires_in === undefined
+          ? undefined
+          : (iat + this.rawToken.expires_in!) * 1000;
+      return this.rawToken;
+    } catch (e) {
+      this.rawToken = undefined;
+      this.tokenExpires = undefined;
+      if (e instanceof Error) {
+        throw Error("failed to get token: " + e.message);
+      } else {
+        throw Error("failed to get token: " + String(e));
+      }
+    }
+  }
+}

--- a/app/utils/model.ts
+++ b/app/utils/model.ts
@@ -200,5 +200,6 @@ export function isModelAvailableInServer(
 ) {
   const fullName = `${modelName}@${providerName}`;
   const modelTable = collectModelTable(DEFAULT_MODELS, customModels);
+  //TODO: this always return false, because providerName's first letter is capitalized, but the providerName in modelTable is lowercase
   return modelTable[fullName]?.available === false;
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "heic2any": "^0.0.4",
     "html-to-image": "^1.11.11",
     "idb-keyval": "^6.2.1",
+    "jose": "^5.9.6",
     "lodash-es": "^4.17.21",
     "markdown-to-txt": "^2.0.1",
     "mermaid": "^10.6.1",

--- a/test/model-provider.test.ts
+++ b/test/model-provider.test.ts
@@ -1,4 +1,4 @@
-import { getModelProvider } from "../app/utils/model";
+import { getModelProvider, isModelAvailableInServer } from "../app/utils/model";
 
 describe("getModelProvider", () => {
   test("should return model and provider when input contains '@'", () => {
@@ -27,5 +27,17 @@ describe("getModelProvider", () => {
     const [model, provider] = getModelProvider(input);
     expect(model).toBe("");
     expect(provider).toBeUndefined();
+  });
+});
+
+describe("isModelAvailableInServer", () => {
+  test("works when model null", () => {
+    const jsonBody = JSON.parse("{}") as { model?: string };
+    const result = isModelAvailableInServer(
+      "gpt-3.5-turbo@OpenAI",
+      jsonBody.model as string,
+      "OpenAI",
+    );
+    expect(result).toBe(false);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5782,6 +5782,11 @@ jest@^29.7.0:
     import-local "^3.0.2"
     jest-cli "^29.7.0"
 
+jose@^5.9.6:
+  version "5.9.6"
+  resolved "https://mirrors.cloud.tencent.com/npm/jose/-/jose-5.9.6.tgz#77f1f901d88ebdc405e57cce08d2a91f47521883"
+  integrity sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] feat    <!-- 引入新功能 | Introduce new features -->
- [ ] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [ ] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don’t modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->

#### 🔀 变更说明 | Description of Change

增加利用Google Cloud Vertex AI平台对Google和Anthropic模型的支持

#### 📝 补充信息 | Additional Information

操作指南：
1. 定义`VERTEX_AI_URL`环境变量，指向 Vertex AI 的 Endpoint 地址，也可以使用 Cloudflare AI Gateway 对它进行代理
  - 这个URL里指定了提供商，也指定了模型的型号
  - 注：如果是Gemini模型，需要在完整地址后面加上`?alt=sse`
3. 定义`GOOGLE_CLOUD_JSON_KEY`环境变量，将 Google Cloud 里面的 Service Account 分配的 JSON 密钥内容贴上
  - 因为JSON密钥有多行且有双引号，所以变量内容要使用单引号`'`进行包裹。
4. 前端任选指定供应商的模型，进行使用
  - 如果`VERTEX_AI_URL` Endpoint 是 Google 的模型，就任选 Google 的一个模型，如果是 Claude 模型就任选 Anthropic 的模型
  - 也可以通过`CUSTOM_MODELS`结合`DEFAULT_MODEL`环境变量进行默认指定
 
.env.local 环境变量定义样列
```env
CODE=<Your Backend Pasword>
# 必填的两个变量
VERTEX_AI_URL='https://<LOC>-aiplatform.googleapis.com/v1/projects/<PROJECT>/locations/<LOC>/publishers/anthropic/models/claude-3-5-sonnet@20240620:streamRawPredict'
GOOGLE_CLOUD_JSON_KEY='{
  "type": "service_account",
  "project_id": "******************",
  "private_key_id": ""******************",",
  "private_key": "-----BEGIN PRIVATE KEY**********-----END PRIVATE KEY-----\n",
  "client_email": "********@*****.iam.gserviceaccount.com",
  "client_id": "****************",
  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
  "token_uri": "https://oauth2.googleapis.com/token",
  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/**********.iam.gserviceaccount.com",
  "universe_domain": "googleapis.com"
}'
# 可选填，注意要带上Provider
DEFAULT_MODEL=claude-vertex@Anthropic
CUSTOM_MODELS=+claude-vertex@Anthropic
```