### PR TITLE
🎨 style(setting): Place custom-model's input a separated row.

### DIFF
--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -1771,9 +1771,11 @@ export function Settings() {
           <ListItem
             title={Locale.Settings.Access.CustomModel.Title}
             subTitle={Locale.Settings.Access.CustomModel.SubTitle}
+            vertical={true}
           >
             <input
               aria-label={Locale.Settings.Access.CustomModel.Title}
+              style={{ width: "100%", maxWidth: "unset", textAlign: "left" }}
               type="text"
               value={config.customModels}
               placeholder="model1,model2,model3"


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] feat    <!-- 引入新功能 | Introduce new features -->
- [ ] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [x] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don’t modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->

#### 🔀 变更说明 | Description of Change

<!-- 
感谢您的 Pull Request ，请提供此 Pull Request 的变更说明
Thank you for your Pull Request. Please provide a description above.
-->

自定义模型列表在 NextChat 中是否非常重要的操作，但是在设置界面中，「自定义模型」只有非常短小的一个 input 区域，非常不便于编写长自定义本文。

本 PR 将 CustomModel 设置转为 vertical 布局，从而让 input 元素单起一行，更加方便编辑。

效果如下。

变更前：

![image](https://github.com/user-attachments/assets/7a25ccfe-c9ed-4058-a01d-9d1cbcaaefb9)

变更后：
 
![image](https://github.com/user-attachments/assets/880d6c63-5aa4-4ba1-9004-2818cda25133)


#### 📝 补充信息 | Additional Information

<!-- 
请添加与此 Pull Request 相关的补充信息
Add any other context about the Pull Request here.
-->

移动端下看上去应该也没啥问题。

![image](https://github.com/user-attachments/assets/88adbc5e-aad7-4773-aff9-ee4a90d021a6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new input field for specifying custom models in the Settings component.
	- Enhanced dynamic updates to the configuration as users type in the custom models input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->