### PR TITLE
fix: allow isVisionModel utility function read env var

### DIFF
--- a/app/utils.ts
+++ b/app/utils.ts
@@ -254,11 +254,16 @@ export function getMessageImages(message: RequestMessage): string[] {
 }
 
 export function isVisionModel(model: string) {
-  const clientConfig = getClientConfig();
-  const envVisionModels = clientConfig?.visionModels
-    ?.split(",")
-    .map((m) => m.trim());
-  if (envVisionModels?.includes(model)) {
+  const clientVisionModels = getClientConfig()?.visionModels || "";
+  const envVisionModels = process.env.VISION_MODELS || "";
+  const allVisionModels = `${clientVisionModels},${envVisionModels}`;
+
+  const visionModelsList = allVisionModels
+    .split(",")
+    .filter(Boolean)
+    .map((m: string) => m.trim());
+
+  if (visionModelsList.includes(model)) {
     return true;
   }
   return (

--- a/test/vision-model-checker.test.ts
+++ b/test/vision-model-checker.test.ts
@@ -49,10 +49,11 @@ describe("isVisionModel", () => {
   });
 
   test("should identify models from VISION_MODELS env var", () => {
-    process.env.VISION_MODELS = "custom-vision-model,another-vision-model";
+    process.env.VISION_MODELS = "custom-vision-model,another-vision-model,OpenGVLab/InternVL2-26B";
     
     expect(isVisionModel("custom-vision-model")).toBe(true);
     expect(isVisionModel("another-vision-model")).toBe(true);
+    expect(isVisionModel("OpenGVLab/InternVL2-26B")).toBe(true);
     expect(isVisionModel("unrelated-model")).toBe(false);
   });
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] feat    <!-- 引入新功能 | Introduce new features -->
- [x] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [ ] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don’t modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->

#### 🔀 变更说明 | Description of Change

Before the fix, the `isVisionModel` function retrieved `VISION_MODELS` from the `getClientConfig` function. However, the `getClientConfig` function was unable to read `VISION_MODELS` from the runtime environment variables. This issue caused visual models outside the predefined and built-in configurations to be evaluated as `false` by the `isVisionModel` function, resulting in the loss of their visual functionality. Specifically, the `VISION_MODELS` environment variable passed by users in Docker did not take effect.

After the fix, the `isVisionModel` function can now retrieve `VISION_MODELS` not only from `BuildConfig` but also from the runtime environment variables, resolving the issue.

<!-- 
感谢您的 Pull Request ，请提供此 Pull Request 的变更说明
Thank you for your Pull Request. Please provide a description above.
-->

#### 📝 补充信息 | Additional Information

Accordingly, the test unit `test/vision-model-checker.test.ts` was updated. Custom visual models were passed into `process.env.VISION_MODELS`, and the tests were successfully passed.

```ts
process.env.VISION_MODELS = "OpenGVLab/InternVL2-26B";
expect(isVisionModel("OpenGVLab/InternVL2-26B")).toBe(true);
```

<!-- 
请添加与此 Pull Request 相关的补充信息
Add any other context about the Pull Request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced model checking by integrating vision models from both client configuration and an environment variable.
	- Added support for a new vision model, `OpenGVLab/InternVL2-26B`.
  
- **Bug Fixes**
	- Improved accuracy in identifying vision models through updated logic. 

- **Tests**
	- Updated test cases to include the new vision model and ensure correct functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->