### PR TITLE
fix custom models setting

### DIFF
--- a/app/api/common.ts
+++ b/app/api/common.ts
@@ -124,7 +124,7 @@ export async function requestOpenai(req: NextRequest) {
           [
             ServiceProvider.OpenAI,
             ServiceProvider.Azure,
-            jsonBody?.model as string, // support provider-unspecified model
+            "custom" as string, // support provider-unspecified model
           ],
         )
       ) {

--- a/app/utils/model.ts
+++ b/app/utils/model.ts
@@ -66,8 +66,8 @@ export function collectModelTable(
 
   // default models
   models.forEach((m) => {
-    // using <modelName>@<providerId> as fullName
-    modelTable[`${m.name}@${m?.provider?.id}`] = {
+    // using <modelName>@<providerType> as fullName
+    modelTable[`${m.name}@${m?.provider?.providerType}`] = {
       ...m,
       displayName: m.name, // 'provider' is copied over if it exists
     };
@@ -126,7 +126,7 @@ export function collectModelTable(
             displayName: displayName || customModelName,
             available,
             provider, // Use optional chaining
-            sorted: CustomSeq.next(`${customModelName}@${provider?.id}`),
+            sorted: CustomSeq.next(`${customModelName}@${provider?.providerType}`),
           };
         }
       }

--- a/test/model-available.test.ts
+++ b/test/model-available.test.ts
@@ -53,7 +53,7 @@ describe("isModelNotavailableInServer", () => {
     expect(result).toBe(true);
   });
 
-  // FIXME: 这个测试用例有问题，需要修复
+  // FIXME: 这个测试用例有问题，需要修复 ？？？
   //   test("support passing multiple providers, model available on one of the providers will return false", () => {
   //     const customModels = "-all,gpt-4@google";
   //     const modelName = "gpt-4";
@@ -69,7 +69,19 @@ describe("isModelNotavailableInServer", () => {
   test("test custom model without setting provider", () => {
     const customModels = "-all,mistral-large";
     const modelName = "mistral-large";
-    const providerNames = modelName;
+    const providerNames = "custom";
+    const result = isModelNotavailableInServer(
+      customModels,
+      modelName,
+      providerNames,
+    );
+    expect(result).toBe(false);
+  });
+
+  test("test custom model with non-standard provider", () => {
+    const customModels = "-all,deepseek-chat@DeepSeek";
+    const modelName = "deepseek-chat";
+    const providerNames = "custom";
     const result = isModelNotavailableInServer(
       customModels,
       modelName,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] feat    <!-- 引入新功能 | Introduce new features -->
- [x] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [ ] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don’t modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->

#### 🔀 变更说明 | Description of Change

在[修复模型可用性检验](https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/commit/d91af7f9831a44a4bcafc9aef8b38dfef5739880)后产生的新问题，在原项目中用户可以省略后缀`@OpenAI`或者使用任意非标准后缀标注 `@xxx` 来通过 OpenAI 格式调用指定模型，任意后缀导致无法直接通过模型名称索引到 modelTable，将 fullname 修改为 `<modelName>@<providerType>` 的形式，所有非标后缀使用默认 custom 作为后缀修饰，确保模型可以被索引到

一些相关话题：
https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/issues/5001#issuecomment-2564601133
https://linux.do/t/topic/318245

#### 📝 补充信息 | Additional Information

<!-- 
请添加与此 Pull Request 相关的补充信息
Add any other context about the Pull Request here.
-->
