### PR TITLE
docs: add DEEPSEEK_API_KEY and DEEPSEEK_URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,14 @@ ChatGLM Api Key.
 
 ChatGLM Api Url.
 
+### `DEEPSEEK_API_KEY` (optional)
+
+DeepSeek Api Key.
+
+### `DEEPSEEK_URL` (optional)
+
+DeepSeek Api Url.
+
 ### `HIDE_USER_API_KEY` (optional)
 
 > Default: Empty

--- a/README_CN.md
+++ b/README_CN.md
@@ -192,6 +192,14 @@ ChatGLM Api Key.
 
 ChatGLM Api Url.
 
+### `DEEPSEEK_API_KEY` (可选)
+
+DeepSeek Api Key.
+
+### `DEEPSEEK_URL` (可选)
+
+DeepSeek Api Url.
+
 
 ### `HIDE_USER_API_KEY` （可选）
 

--- a/app/client/platforms/deepseek.ts
+++ b/app/client/platforms/deepseek.ts
@@ -35,7 +35,7 @@ export class DeepSeekApi implements LLMApi {
     let baseUrl = "";
 
     if (accessStore.useCustomConfig) {
-      baseUrl = accessStore.moonshotUrl;
+      baseUrl = accessStore.deepseekUrl;
     }
 
     if (baseUrl.length === 0) {


### PR DESCRIPTION
docs: add DEEPSEEK_API_KEY and DEEPSEEK_URL in README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for DeepSeek API configuration with optional environment variables: `DEEPSEEK_API_KEY` and `DEEPSEEK_URL`.
- **Documentation**
  - Updated README and README_CN with new DeepSeek API configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->