### PR TITLE
修复 VISION_MDOELS 在 docker 运行阶段不生效的问题

### DIFF
--- a/app/api/config/route.ts
+++ b/app/api/config/route.ts
@@ -14,6 +14,7 @@ const DANGER_CONFIG = {
   disableFastLink: serverConfig.disableFastLink,
   customModels: serverConfig.customModels,
   defaultModel: serverConfig.defaultModel,
+  visionModels: serverConfig.visionModels,
 };
 
 declare global {

--- a/app/config/build.ts
+++ b/app/config/build.ts
@@ -40,7 +40,6 @@ export const getBuildConfig = () => {
     buildMode,
     isApp,
     template: process.env.DEFAULT_INPUT_TEMPLATE ?? DEFAULT_INPUT_TEMPLATE,
-    visionModels: process.env.VISION_MODELS || "",
   };
 };
 

--- a/app/config/server.ts
+++ b/app/config/server.ts
@@ -23,6 +23,7 @@ declare global {
       DISABLE_FAST_LINK?: string; // disallow parse settings from url or not
       CUSTOM_MODELS?: string; // to control custom models
       DEFAULT_MODEL?: string; // to control default model in every new chat window
+      VISION_MODELS?: string; // to control vision models
 
       // stability only
       STABILITY_URL?: string;
@@ -128,6 +129,7 @@ export const getServerSideConfig = () => {
   const disableGPT4 = !!process.env.DISABLE_GPT4;
   let customModels = process.env.CUSTOM_MODELS ?? "";
   let defaultModel = process.env.DEFAULT_MODEL ?? "";
+  let visionModels = process.env.VISION_MODELS ?? "";
 
   if (disableGPT4) {
     if (customModels) customModels += ",";
@@ -249,6 +251,7 @@ export const getServerSideConfig = () => {
     disableFastLink: !!process.env.DISABLE_FAST_LINK,
     customModels,
     defaultModel,
+    visionModels,
     allowedWebDavEndpoints,
   };
 };

--- a/app/store/access.ts
+++ b/app/store/access.ts
@@ -131,6 +131,7 @@ const DEFAULT_ACCESS_STATE = {
   disableFastLink: false,
   customModels: "",
   defaultModel: "",
+  visionModels: "",
 
   // tts config
   edgeTTSVoiceName: "zh-CN-YunxiNeural",
@@ -145,7 +146,10 @@ export const useAccessStore = createPersistStore(
 
       return get().needCode;
     },
-
+    setVisionModels() {
+      this.fetch();
+      return get().visionModels;
+    },
     edgeVoiceName() {
       this.fetch();
 

--- a/app/store/access.ts
+++ b/app/store/access.ts
@@ -146,7 +146,7 @@ export const useAccessStore = createPersistStore(
 
       return get().needCode;
     },
-    setVisionModels() {
+    getVisionModels() {
       this.fetch();
       return get().visionModels;
     },

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -6,7 +6,7 @@ import { ServiceProvider } from "./constant";
 // import { fetch as tauriFetch, ResponseType } from "@tauri-apps/api/http";
 import { fetch as tauriStreamFetch } from "./utils/stream";
 import { VISION_MODEL_REGEXES, EXCLUDE_VISION_MODEL_REGEXES } from "./constant";
-import { getClientConfig } from "./config/client";
+import { useAccessStore } from "./store";
 import { ModelSize } from "./typing";
 
 export function trimTopic(topic: string) {
@@ -255,8 +255,8 @@ export function getMessageImages(message: RequestMessage): string[] {
 }
 
 export function isVisionModel(model: string) {
-  const clientConfig = getClientConfig();
-  const envVisionModels = clientConfig?.visionModels
+  const visionModels = useAccessStore.getState().visionModels;
+  const envVisionModels = visionModels
     ?.split(",")
     .map((m) => m.trim());
   if (envVisionModels?.includes(model)) {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] feat    <!-- 引入新功能 | Introduce new features -->
- [x] fix    <!-- 修复 Bug | Fix a bug -->
- [ ] refactor    <!-- 重构代码（既不修复 Bug 也不添加新功能） | Refactor code that neither fixes a bug nor adds a feature -->
- [ ] perf    <!-- 提升性能的代码变更 | A code change that improves performance -->
- [ ] style    <!-- 添加或更新不影响代码含义的样式文件 | Add or update style files that do not affect the meaning of the code -->
- [ ] test    <!-- 添加缺失的测试或纠正现有的测试 | Adding missing tests or correcting existing tests -->
- [ ] docs    <!-- 仅文档更新 | Documentation only changes -->
- [ ] ci    <!-- 修改持续集成配置文件和脚本 | Changes to our CI configuration files and scripts -->
- [ ] chore    <!-- 其他不修改 src 或 test 文件的变更 | Other changes that don’t modify src or test files -->
- [ ] build    <!-- 进行架构变更 | Make architectural changes -->

#### 🔀 变更说明 | Description of Change

解决问题：https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/issues/6007

原方法 VISION_MDOELS 只在构建过程生效，无法在 docker 运行时起作用

（另一个环境变量 DEFAULT_INPUT_TEMPLATE 同理，这里暂不做修改）

<!-- 
感谢您的 Pull Request ，请提供此 Pull Request 的变更说明
Thank you for your Pull Request. Please provide a description above.
-->

#### 📝 补充信息 | Additional Information

<!-- 
请添加与此 Pull Request 相关的补充信息
Add any other context about the Pull Request here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added support for configurable vision models through environment variables and application state management.
  - Introduced a new method for retrieving vision models in the access store.

- **Configuration Updates**
  - Enhanced server-side configuration to include a new optional environment variable for vision models.
  - Updated the configuration object to reflect changes in vision model handling.

- **Technical Improvements**
  - Modified utility functions to retrieve vision models from the access store, improving state management capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->